### PR TITLE
Add full-screen designer with template update functionality

### DIFF
--- a/app/routes/api.templates.save.tsx
+++ b/app/routes/api.templates.save.tsx
@@ -16,23 +16,51 @@ export async function action({ request }: ActionFunctionArgs) {
     const name = formData.get("name") as string;
     const canvasData = formData.get("canvasData") as string;
     const thumbnail = formData.get("thumbnail") as string | null;
+    const templateId = formData.get("templateId") as string | null;
 
     if (!name || !canvasData) {
       return json({ error: "Name and canvas data are required" }, { status: 400 });
     }
 
-    // Create template in database first to get the ID
-    const template = await db.template.create({
-      data: {
-        name,
-        shop: session.shop,
-        canvasData,
-        thumbnail: null, // We'll update this after S3 upload
-      },
-    });
+    let template;
+    
+    if (templateId) {
+      // Update existing template
+      // First verify the template belongs to this shop
+      const existingTemplate = await db.template.findFirst({
+        where: {
+          id: templateId,
+          shop: session.shop,
+        },
+      });
+
+      if (!existingTemplate) {
+        return json({ error: "Template not found or access denied" }, { status: 404 });
+      }
+
+      // Update the template
+      template = await db.template.update({
+        where: { id: templateId },
+        data: {
+          name,
+          canvasData,
+          updatedAt: new Date(),
+        },
+      });
+    } else {
+      // Create new template
+      template = await db.template.create({
+        data: {
+          name,
+          shop: session.shop,
+          canvasData,
+          thumbnail: null, // We'll update this after S3 upload
+        },
+      });
+    }
 
     // Upload thumbnail to S3 if provided
-    let thumbnailUrl = null;
+    let thumbnailUrl = template.thumbnail; // Keep existing thumbnail if not updating
     if (thumbnail) {
       try {
         const s3Key = generateTemplateThumbnailKey(session.shop, template.id);
@@ -45,7 +73,15 @@ export async function action({ request }: ActionFunctionArgs) {
         });
       } catch (s3Error) {
         console.error("Error uploading thumbnail to S3:", s3Error);
-        // Continue without thumbnail - non-critical error
+        // Return error info for debugging
+        return json({ 
+          success: true, 
+          template: {
+            ...template,
+            thumbnail: template.thumbnail, // Keep existing thumbnail
+          },
+          warning: `Thumbnail upload failed: ${s3Error instanceof Error ? s3Error.message : 'Unknown error'}`
+        });
       }
     }
 

--- a/app/routes/app.designer.tsx
+++ b/app/routes/app.designer.tsx
@@ -41,7 +41,12 @@ export default function Designer() {
       <Layout>
         <Layout.Section>
           <Card>
-            <div style={{ padding: '0' }}>
+            <div style={{ 
+              padding: '0',
+              height: 'calc(100vh - 120px)', // Account for header and padding
+              minHeight: '600px',
+              position: 'relative'
+            }}>
               <DesignerCanvas initialTemplate={template} />
             </div>
           </Card>


### PR DESCRIPTION
## Summary
- Implement full-screen designer modal with proper state preservation
- Add template update functionality to override existing templates when editing
- Fix critical bug where element transformation properties weren't being saved

## Key Changes

### Full-Screen Designer Modal
- Added proxy route for standalone designer access via `/api/customizer/{templateId}/{variantId}`
- Implemented modal that opens designer in full-screen for better user experience
- Preserves state between embedded and full-screen views
- Supports text editing capabilities from the modal

### Template Update Functionality
- Modified save logic to detect when editing an existing template
- API endpoint now handles both create and update operations
- Button text changes to "Update Template" when editing
- Prevents duplicate templates when making changes

### State Preservation Fix
- Fixed critical bug where visual properties (fontSize, fill, rotation, scale) weren't saved
- Added onTransformEnd handlers to all elements to capture transformations
- Extended element state interfaces to include all visual properties
- Ensures templates are properly saved and restored with complete visual state

## Test Plan
- [x] Create new template and verify it saves correctly
- [x] Edit existing template and verify it updates instead of creating duplicate
- [x] Add various elements with transformations (rotate, scale) and verify they persist
- [x] Test full-screen designer modal functionality
- [x] Verify text updates from modal are preserved
- [x] Test template thumbnail generation and S3 upload

🤖 Generated with [Claude Code](https://claude.ai/code)