### PR TITLE
Fix: Persist variant swatch previews after page refresh

### DIFF
--- a/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
+++ b/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
@@ -36,6 +36,29 @@
   <script>
     let variantChangeCount = 0;
     
+    // Helper function to ensure Konva and other resources are loaded
+    async function ensureResourcesLoaded() {
+      // Check if Konva is already loaded
+      if (typeof Konva !== 'undefined') {
+        return;
+      }
+      
+      // Load Konva if not already loaded
+      return new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = 'https://unpkg.com/konva@9.3.3/konva.min.js';
+        script.onload = () => {
+          console.log('[ensureResourcesLoaded] Konva loaded successfully');
+          resolve();
+        };
+        script.onerror = () => {
+          console.error('[ensureResourcesLoaded] Failed to load Konva');
+          reject(new Error('Failed to load Konva'));
+        };
+        document.head.appendChild(script);
+      });
+    }
+    
     document.addEventListener('DOMContentLoaded', function() {
       // Create a map of variant data
       const variantData = {
@@ -438,6 +461,214 @@
         if (initialVariantId) {
           checkSavedCustomization(initialVariantId);
         }
+        
+        // Regenerate variant swatches if we have global canvas state
+        if (hasActiveCustomization) {
+          regenerateVariantSwatchesOnLoad();
+        }
+      }
+      
+      // Function to regenerate variant swatches on page load
+      async function regenerateVariantSwatchesOnLoad() {
+        console.log('[ProductCustomizer] Regenerating variant swatches on page load');
+        
+        // Get the global canvas state
+        const globalStateKey = 'customization_global_state';
+        const savedGlobalState = localStorage.getItem(globalStateKey);
+        
+        if (!savedGlobalState) {
+          console.log('[ProductCustomizer] No global canvas state found');
+          return;
+        }
+        
+        try {
+          const globalData = JSON.parse(savedGlobalState);
+          if (!globalData.canvasState || !globalData.timestamp || 
+              Date.now() - globalData.timestamp >= 30 * 24 * 60 * 60 * 1000) {
+            console.log('[ProductCustomizer] Global canvas state expired or invalid');
+            return;
+          }
+          
+          console.log('[ProductCustomizer] Valid global canvas state found, regenerating swatches...');
+          
+          // Wait for resources to load
+          await ensureResourcesLoaded();
+          
+          // Wait a bit more for DOM to be fully ready
+          await new Promise(resolve => setTimeout(resolve, 500));
+          
+          // Check if batch renderer is available
+          if (typeof ProductCustomizerBatchRenderer === 'undefined') {
+            console.log('[ProductCustomizer] Waiting for batch renderer to load...');
+            // Try to wait for it
+            let attempts = 0;
+            while (typeof ProductCustomizerBatchRenderer === 'undefined' && attempts < 20) {
+              await new Promise(resolve => setTimeout(resolve, 100));
+              attempts++;
+            }
+            
+            if (typeof ProductCustomizerBatchRenderer === 'undefined') {
+              console.error('[ProductCustomizer] Batch renderer not available after waiting');
+              return;
+            }
+          }
+          
+          // Get current variant info
+          const currentVariantTitle = getVariantTitleForId(initialVariantId);
+          if (!currentVariantTitle) {
+            console.log('[ProductCustomizer] Could not determine variant title');
+            return;
+          }
+          
+          const parts = currentVariantTitle.split(' / ');
+          const edgePattern = parts.length > 1 ? parts[1].trim() : null;
+          const currentColor = getColorFromTitle(currentVariantTitle);
+          
+          if (!edgePattern || !currentColor) {
+            console.log('[ProductCustomizer] Could not determine pattern or color');
+            return;
+          }
+          
+          console.log(`[ProductCustomizer] Current variant: ${currentColor} / ${edgePattern}`);
+          
+          // Get all color variants for this pattern
+          const colorVariants = getColorVariantsForPatternOnLoad(edgePattern);
+          console.log(`[ProductCustomizer] Found ${colorVariants.length} color variants`);
+          
+          // Create batch renderer
+          const batchRenderer = new ProductCustomizerBatchRenderer();
+          
+          // Process each variant
+          let processedCount = 0;
+          for (const variant of colorVariants) {
+            try {
+              console.log(`[ProductCustomizer] Processing ${variant.color}`);
+              
+              // Get base image URL
+              const baseImageUrl = getBaseImageUrlForVariant(variant.color, edgePattern);
+              if (!baseImageUrl) {
+                console.log(`[ProductCustomizer] No base image for ${variant.color}`);
+                continue;
+              }
+              
+              // Render preview
+              const preview = await batchRenderer.renderVariantPreview(
+                globalData.canvasState,
+                baseImageUrl,
+                { width: 128, height: 128, pixelRatio: 0.5 }
+              );
+              
+              if (preview && variant.element) {
+                // Store original if not already stored
+                if (!variant.element.dataset.originalBackground) {
+                  variant.element.dataset.originalBackground = variant.element.getAttribute('style');
+                }
+                
+                variant.element.setAttribute('style', `--swatch-background: url(${preview});`);
+                variant.element.setAttribute('data-multi-preview', 'true');
+                
+                processedCount++;
+              }
+            } catch (error) {
+              console.error(`[ProductCustomizer] Failed to process ${variant.color}:`, error);
+            }
+          }
+          
+          // Cleanup
+          batchRenderer.destroy();
+          console.log(`[ProductCustomizer] Regenerated ${processedCount} variant swatches`);
+          
+        } catch (error) {
+          console.error('[ProductCustomizer] Error regenerating swatches:', error);
+        }
+      }
+      
+      // Helper function to get variant title by ID
+      function getVariantTitleForId(variantId) {
+        const variantInfo = variantData[variantId];
+        return variantInfo ? variantInfo.title : null;
+      }
+      
+      // Helper function to extract color from variant title
+      function getColorFromTitle(title) {
+        const parts = title.split(' / ');
+        return parts.length > 0 ? parts[0].trim() : null;
+      }
+      
+      // Helper function to get color variants for pattern on page load
+      function getColorVariantsForPatternOnLoad(pattern) {
+        const variants = [];
+        
+        // Find all color swatches
+        const swatches = document.querySelectorAll('.swatch.color');
+        
+        swatches.forEach(swatch => {
+          const colorName = swatch.getAttribute('data-swatch-value') || 
+                            swatch.getAttribute('data-value') ||
+                            swatch.querySelector('span')?.getAttribute('data-swatch-value');
+          
+          if (colorName) {
+            variants.push({
+              color: colorName,
+              element: swatch
+            });
+          }
+        });
+        
+        // If no swatches found, try radio inputs
+        if (variants.length === 0) {
+          const inputs = document.querySelectorAll('input[type="radio"][name*="Color"]');
+          inputs.forEach(input => {
+            const parentLabel = input.closest('label');
+            const swatch = parentLabel?.querySelector('.swatch') || 
+                          (input.nextElementSibling?.classList.contains('swatch') ? input.nextElementSibling : null);
+            
+            if (swatch) {
+              variants.push({
+                color: input.value,
+                element: swatch
+              });
+            }
+          });
+        }
+        
+        return variants;
+      }
+      
+      // Helper function to get base image URL for a variant
+      function getBaseImageUrlForVariant(color, pattern) {
+        // Try to find the swatch element for this color
+        const swatch = document.querySelector(`.swatch[data-swatch-value="${color}"]`) ||
+                      document.querySelector(`.swatch[data-value="${color}"]`);
+        
+        if (swatch) {
+          const style = swatch.getAttribute('style');
+          if (style) {
+            const match = style.match(/url\(([^)]+)\)/);
+            if (match && match[1]) {
+              return match[1].replace(/["']/g, '');
+            }
+          }
+        }
+        
+        // Try by input value
+        const inputs = document.querySelectorAll('input[type="radio"]');
+        for (const input of inputs) {
+          if (input.value === color) {
+            const nextSwatch = input.nextElementSibling;
+            if (nextSwatch?.classList.contains('swatch')) {
+              const style = nextSwatch.getAttribute('style');
+              if (style) {
+                const match = style.match(/url\(([^)]+)\)/);
+                if (match && match[1]) {
+                  return match[1].replace(/["']/g, '');
+                }
+              }
+            }
+          }
+        }
+        
+        return null;
       }
       
       initializeWhenReady();

--- a/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
+++ b/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
@@ -36,29 +36,6 @@
   <script>
     let variantChangeCount = 0;
     
-    // Helper function to ensure Konva and other resources are loaded
-    async function ensureResourcesLoaded() {
-      // Check if Konva is already loaded
-      if (typeof Konva !== 'undefined') {
-        return;
-      }
-      
-      // Load Konva if not already loaded
-      return new Promise((resolve, reject) => {
-        const script = document.createElement('script');
-        script.src = 'https://unpkg.com/konva@9.3.3/konva.min.js';
-        script.onload = () => {
-          console.log('[ensureResourcesLoaded] Konva loaded successfully');
-          resolve();
-        };
-        script.onerror = () => {
-          console.error('[ensureResourcesLoaded] Failed to load Konva');
-          reject(new Error('Failed to load Konva'));
-        };
-        document.head.appendChild(script);
-      });
-    }
-    
     document.addEventListener('DOMContentLoaded', function() {
       // Create a map of variant data
       const variantData = {
@@ -462,125 +439,138 @@
           checkSavedCustomization(initialVariantId);
         }
         
-        // Regenerate variant swatches if we have global canvas state
+        // Restore variant swatches if we have global canvas state
         if (hasActiveCustomization) {
-          regenerateVariantSwatchesOnLoad();
+          restoreVariantSwatchesOnLoad();
+        }
+        
+        // Clean up expired localStorage data
+        cleanupExpiredData();
+      }
+      
+      // Function to clean up expired localStorage data
+      function cleanupExpiredData() {
+        const keysToCheck = [];
+        
+        // Find all variant preview keys
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i);
+          if (key && key.startsWith('variant_previews_')) {
+            keysToCheck.push(key);
+          }
+        }
+        
+        // Check and remove expired data
+        keysToCheck.forEach(key => {
+          try {
+            const data = JSON.parse(localStorage.getItem(key));
+            if (!data.timestamp || Date.now() - data.timestamp >= 30 * 24 * 60 * 60 * 1000) {
+              localStorage.removeItem(key);
+              console.log('[ProductCustomizer] Removed expired data:', key);
+            }
+          } catch (e) {
+            // Invalid data, remove it
+            localStorage.removeItem(key);
+          }
+        });
+        
+        // Also check if global canvas state exists but is expired
+        // If so, clear all associated variant previews
+        const globalStateKey = 'customization_global_state';
+        const savedGlobalState = localStorage.getItem(globalStateKey);
+        if (!savedGlobalState || !hasActiveCustomization) {
+          // No active customization, clear all variant previews
+          keysToCheck.forEach(key => {
+            if (key.startsWith('variant_previews_')) {
+              localStorage.removeItem(key);
+              console.log('[ProductCustomizer] Cleared variant previews (no active customization)');
+            }
+          });
         }
       }
       
-      // Function to regenerate variant swatches on page load
-      async function regenerateVariantSwatchesOnLoad() {
-        console.log('[ProductCustomizer] Regenerating variant swatches on page load');
+      // Function to restore saved variant swatches on page load
+      function restoreVariantSwatchesOnLoad() {
+        console.log('[ProductCustomizer] Checking for saved variant swatches');
         
-        // Get the global canvas state
-        const globalStateKey = 'customization_global_state';
-        const savedGlobalState = localStorage.getItem(globalStateKey);
+        // Get current variant info to determine the pattern
+        const currentVariantTitle = getVariantTitleForId(initialVariantId);
+        if (!currentVariantTitle) {
+          console.log('[ProductCustomizer] Could not determine variant title');
+          return;
+        }
         
-        if (!savedGlobalState) {
-          console.log('[ProductCustomizer] No global canvas state found');
+        const parts = currentVariantTitle.split(' / ');
+        const edgePattern = parts.length > 1 ? parts[1].trim() : null;
+        
+        if (!edgePattern) {
+          console.log('[ProductCustomizer] Could not determine pattern');
+          return;
+        }
+        
+        // Look for saved variant previews for this pattern
+        const variantPreviewsKey = `variant_previews_${edgePattern}`;
+        const savedPreviews = localStorage.getItem(variantPreviewsKey);
+        
+        if (!savedPreviews) {
+          console.log('[ProductCustomizer] No saved previews found for pattern:', edgePattern);
           return;
         }
         
         try {
-          const globalData = JSON.parse(savedGlobalState);
-          if (!globalData.canvasState || !globalData.timestamp || 
-              Date.now() - globalData.timestamp >= 30 * 24 * 60 * 60 * 1000) {
-            console.log('[ProductCustomizer] Global canvas state expired or invalid');
+          const previewData = JSON.parse(savedPreviews);
+          
+          // Check if data is less than 30 days old
+          if (!previewData.timestamp || Date.now() - previewData.timestamp >= 30 * 24 * 60 * 60 * 1000) {
+            console.log('[ProductCustomizer] Saved previews expired');
+            localStorage.removeItem(variantPreviewsKey);
             return;
           }
           
-          console.log('[ProductCustomizer] Valid global canvas state found, regenerating swatches...');
+          console.log(`[ProductCustomizer] Found saved previews for ${Object.keys(previewData.previews).length} variants`);
           
-          // Wait for resources to load
-          await ensureResourcesLoaded();
-          
-          // Wait a bit more for DOM to be fully ready
-          await new Promise(resolve => setTimeout(resolve, 500));
-          
-          // Check if batch renderer is available
-          if (typeof ProductCustomizerBatchRenderer === 'undefined') {
-            console.log('[ProductCustomizer] Waiting for batch renderer to load...');
-            // Try to wait for it
-            let attempts = 0;
-            while (typeof ProductCustomizerBatchRenderer === 'undefined' && attempts < 20) {
-              await new Promise(resolve => setTimeout(resolve, 100));
-              attempts++;
-            }
+          // Apply saved previews to swatches
+          let restoredCount = 0;
+          Object.entries(previewData.previews).forEach(([color, previewUrl]) => {
+            // Find the swatch element for this color
+            const swatch = document.querySelector(`.swatch[data-swatch-value="${color}"]`) ||
+                          document.querySelector(`.swatch[data-value="${color}"]`);
             
-            if (typeof ProductCustomizerBatchRenderer === 'undefined') {
-              console.error('[ProductCustomizer] Batch renderer not available after waiting');
-              return;
-            }
-          }
-          
-          // Get current variant info
-          const currentVariantTitle = getVariantTitleForId(initialVariantId);
-          if (!currentVariantTitle) {
-            console.log('[ProductCustomizer] Could not determine variant title');
-            return;
-          }
-          
-          const parts = currentVariantTitle.split(' / ');
-          const edgePattern = parts.length > 1 ? parts[1].trim() : null;
-          const currentColor = getColorFromTitle(currentVariantTitle);
-          
-          if (!edgePattern || !currentColor) {
-            console.log('[ProductCustomizer] Could not determine pattern or color');
-            return;
-          }
-          
-          console.log(`[ProductCustomizer] Current variant: ${currentColor} / ${edgePattern}`);
-          
-          // Get all color variants for this pattern
-          const colorVariants = getColorVariantsForPatternOnLoad(edgePattern);
-          console.log(`[ProductCustomizer] Found ${colorVariants.length} color variants`);
-          
-          // Create batch renderer
-          const batchRenderer = new ProductCustomizerBatchRenderer();
-          
-          // Process each variant
-          let processedCount = 0;
-          for (const variant of colorVariants) {
-            try {
-              console.log(`[ProductCustomizer] Processing ${variant.color}`);
-              
-              // Get base image URL
-              const baseImageUrl = getBaseImageUrlForVariant(variant.color, edgePattern);
-              if (!baseImageUrl) {
-                console.log(`[ProductCustomizer] No base image for ${variant.color}`);
-                continue;
-              }
-              
-              // Render preview
-              const preview = await batchRenderer.renderVariantPreview(
-                globalData.canvasState,
-                baseImageUrl,
-                { width: 128, height: 128, pixelRatio: 0.5 }
-              );
-              
-              if (preview && variant.element) {
-                // Store original if not already stored
-                if (!variant.element.dataset.originalBackground) {
-                  variant.element.dataset.originalBackground = variant.element.getAttribute('style');
+            if (!swatch) {
+              // Try finding by input value
+              const inputs = document.querySelectorAll('input[type="radio"][name*="Color"]');
+              for (const input of inputs) {
+                if (input.value === color) {
+                  const nextSwatch = input.nextElementSibling;
+                  if (nextSwatch?.classList.contains('swatch')) {
+                    applyPreviewToSwatch(nextSwatch, previewUrl);
+                    restoredCount++;
+                    break;
+                  }
                 }
-                
-                variant.element.setAttribute('style', `--swatch-background: url(${preview});`);
-                variant.element.setAttribute('data-multi-preview', 'true');
-                
-                processedCount++;
               }
-            } catch (error) {
-              console.error(`[ProductCustomizer] Failed to process ${variant.color}:`, error);
+            } else {
+              applyPreviewToSwatch(swatch, previewUrl);
+              restoredCount++;
             }
-          }
+          });
           
-          // Cleanup
-          batchRenderer.destroy();
-          console.log(`[ProductCustomizer] Regenerated ${processedCount} variant swatches`);
+          console.log(`[ProductCustomizer] Restored ${restoredCount} variant swatches`);
           
         } catch (error) {
-          console.error('[ProductCustomizer] Error regenerating swatches:', error);
+          console.error('[ProductCustomizer] Error restoring swatches:', error);
         }
+      }
+      
+      // Helper function to apply preview to a swatch element
+      function applyPreviewToSwatch(swatch, previewUrl) {
+        // Store original if not already stored
+        if (!swatch.dataset.originalBackground) {
+          swatch.dataset.originalBackground = swatch.getAttribute('style');
+        }
+        
+        swatch.setAttribute('style', `--swatch-background: url(${previewUrl});`);
+        swatch.setAttribute('data-multi-preview', 'true');
       }
       
       // Helper function to get variant title by ID
@@ -589,87 +579,6 @@
         return variantInfo ? variantInfo.title : null;
       }
       
-      // Helper function to extract color from variant title
-      function getColorFromTitle(title) {
-        const parts = title.split(' / ');
-        return parts.length > 0 ? parts[0].trim() : null;
-      }
-      
-      // Helper function to get color variants for pattern on page load
-      function getColorVariantsForPatternOnLoad(pattern) {
-        const variants = [];
-        
-        // Find all color swatches
-        const swatches = document.querySelectorAll('.swatch.color');
-        
-        swatches.forEach(swatch => {
-          const colorName = swatch.getAttribute('data-swatch-value') || 
-                            swatch.getAttribute('data-value') ||
-                            swatch.querySelector('span')?.getAttribute('data-swatch-value');
-          
-          if (colorName) {
-            variants.push({
-              color: colorName,
-              element: swatch
-            });
-          }
-        });
-        
-        // If no swatches found, try radio inputs
-        if (variants.length === 0) {
-          const inputs = document.querySelectorAll('input[type="radio"][name*="Color"]');
-          inputs.forEach(input => {
-            const parentLabel = input.closest('label');
-            const swatch = parentLabel?.querySelector('.swatch') || 
-                          (input.nextElementSibling?.classList.contains('swatch') ? input.nextElementSibling : null);
-            
-            if (swatch) {
-              variants.push({
-                color: input.value,
-                element: swatch
-              });
-            }
-          });
-        }
-        
-        return variants;
-      }
-      
-      // Helper function to get base image URL for a variant
-      function getBaseImageUrlForVariant(color, pattern) {
-        // Try to find the swatch element for this color
-        const swatch = document.querySelector(`.swatch[data-swatch-value="${color}"]`) ||
-                      document.querySelector(`.swatch[data-value="${color}"]`);
-        
-        if (swatch) {
-          const style = swatch.getAttribute('style');
-          if (style) {
-            const match = style.match(/url\(([^)]+)\)/);
-            if (match && match[1]) {
-              return match[1].replace(/["']/g, '');
-            }
-          }
-        }
-        
-        // Try by input value
-        const inputs = document.querySelectorAll('input[type="radio"]');
-        for (const input of inputs) {
-          if (input.value === color) {
-            const nextSwatch = input.nextElementSibling;
-            if (nextSwatch?.classList.contains('swatch')) {
-              const style = nextSwatch.getAttribute('style');
-              if (style) {
-                const match = style.match(/url\(([^)]+)\)/);
-                if (match && match[1]) {
-                  return match[1].replace(/["']/g, '');
-                }
-              }
-            }
-          }
-        }
-        
-        return null;
-      }
       
       initializeWhenReady();
     });

--- a/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
+++ b/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
@@ -254,7 +254,10 @@
                     mainProductImage.style.transition = 'opacity 0.3s, filter 0.3s';
                   }
                   
-                  // Generate preview with full canvas state
+                  // First restore all cached variant swatches
+                  restoreVariantSwatchesOnLoad();
+                  
+                  // Then generate preview for the current variant
                   if (typeof generateVariantPreviewWithCanvasState === 'function') {
                     await generateVariantPreviewWithCanvasState(variantId, templateId, globalData.canvasState);
                   } else {
@@ -324,6 +327,9 @@
                     setTimeout(() => observer.disconnect(), 5000);
                   }
                   
+                  // First restore all cached variant swatches
+                  restoreVariantSwatchesOnLoad();
+                  
                   // Check if the function is available (script is loaded)
                   if (typeof generateVariantPreviewWithText === 'function') {
                     await generateVariantPreviewWithText(variantId, templateId, textData.textUpdates);
@@ -347,6 +353,11 @@
             
             // Only check for saved customization if we don't have global text
             checkSavedCustomization(variantId);
+            
+            // Always restore cached swatches if we have active customization
+            if (hasActiveCustomization) {
+              restoreVariantSwatchesOnLoad();
+            }
           } else {
             // Hide button if variant has no template
             customizeBtn.parentElement.style.display = 'none';
@@ -399,6 +410,9 @@
             if (hasActiveCustomization) {
               event.preventDefault();
               event.stopImmediatePropagation();
+              
+              // Protect customized swatches from being reset
+              protectCustomizedSwatches();
             }
             handleVariantChange(event.detail.variant.id);
           }
@@ -410,6 +424,9 @@
             if (hasActiveCustomization) {
               event.preventDefault();
               event.stopImmediatePropagation();
+              
+              // Protect customized swatches from being reset
+              protectCustomizedSwatches();
             }
             handleVariantChange(event.detail.variant.id);
           }
@@ -422,6 +439,10 @@
           const currentVariantId = urlParams.get('variant');
           if (currentVariantId && currentVariantId !== lastVariantId) {
             lastVariantId = currentVariantId;
+            // Protect swatches before handling change
+            if (hasActiveCustomization) {
+              protectCustomizedSwatches();
+            }
             handleVariantChange(currentVariantId);
           }
         }, 500);
@@ -429,6 +450,10 @@
         // Also listen for form changes on variant selectors
         document.querySelectorAll('[name="id"], [name="variant"]').forEach(function(selector) {
           selector.addEventListener('change', function(event) {
+            // Protect swatches before handling change
+            if (hasActiveCustomization) {
+              protectCustomizedSwatches();
+            }
             handleVariantChange(event.target.value);
           });
         });
@@ -571,6 +596,35 @@
         
         swatch.setAttribute('style', `--swatch-background: url(${previewUrl});`);
         swatch.setAttribute('data-multi-preview', 'true');
+      }
+      
+      // Function to protect customized swatches from being reset by theme
+      function protectCustomizedSwatches() {
+        // Find all customized swatches
+        const customizedSwatches = document.querySelectorAll('[data-multi-preview="true"]');
+        
+        customizedSwatches.forEach(swatch => {
+          // Store current customized background
+          const currentStyle = swatch.getAttribute('style');
+          
+          // Use MutationObserver to prevent changes
+          const observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+              if (mutation.attributeName === 'style' && 
+                  swatch.getAttribute('style') !== currentStyle &&
+                  swatch.dataset.multiPreview === 'true') {
+                // Theme tried to reset the swatch, restore our custom style
+                swatch.setAttribute('style', currentStyle);
+              }
+            });
+          });
+          
+          // Observe for a short time
+          observer.observe(swatch, { attributes: true, attributeFilter: ['style'] });
+          
+          // Stop observing after 2 seconds
+          setTimeout(() => observer.disconnect(), 2000);
+        });
       }
       
       // Helper function to get variant title by ID

--- a/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
+++ b/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
@@ -411,8 +411,11 @@
               event.preventDefault();
               event.stopImmediatePropagation();
               
-              // Protect customized swatches from being reset
-              protectCustomizedSwatches();
+              // Immediately restore swatches and protect them
+              setTimeout(() => {
+                restoreVariantSwatchesOnLoad(event.detail.variant.id);
+                protectCustomizedSwatches();
+              }, 0);
             }
             handleVariantChange(event.detail.variant.id);
           }
@@ -425,8 +428,11 @@
               event.preventDefault();
               event.stopImmediatePropagation();
               
-              // Protect customized swatches from being reset
-              protectCustomizedSwatches();
+              // Immediately restore swatches and protect them
+              setTimeout(() => {
+                restoreVariantSwatchesOnLoad(event.detail.variant.id);
+                protectCustomizedSwatches();
+              }, 0);
             }
             handleVariantChange(event.detail.variant.id);
           }
@@ -441,7 +447,11 @@
             lastVariantId = currentVariantId;
             // Protect swatches before handling change
             if (hasActiveCustomization) {
-              protectCustomizedSwatches();
+              // Immediately restore swatches and protect them
+              setTimeout(() => {
+                restoreVariantSwatchesOnLoad(currentVariantId);
+                protectCustomizedSwatches();
+              }, 0);
             }
             handleVariantChange(currentVariantId);
           }
@@ -452,7 +462,11 @@
           selector.addEventListener('change', function(event) {
             // Protect swatches before handling change
             if (hasActiveCustomization) {
-              protectCustomizedSwatches();
+              // Immediately restore swatches and protect them
+              setTimeout(() => {
+                restoreVariantSwatchesOnLoad(event.target.value);
+                protectCustomizedSwatches();
+              }, 0);
             }
             handleVariantChange(event.target.value);
           });
@@ -557,33 +571,88 @@
           
           console.log(`[ProductCustomizer] Found saved previews for ${Object.keys(previewData.previews).length} variants`);
           
-          // Apply saved previews to swatches
-          let restoredCount = 0;
-          Object.entries(previewData.previews).forEach(([color, previewUrl]) => {
-            // Find the swatch element for this color
-            const swatch = document.querySelector(`.swatch[data-swatch-value="${color}"]`) ||
-                          document.querySelector(`.swatch[data-value="${color}"]`);
-            
-            if (!swatch) {
-              // Try finding by input value
-              const inputs = document.querySelectorAll('input[type="radio"][name*="Color"]');
-              for (const input of inputs) {
-                if (input.value === color) {
-                  const nextSwatch = input.nextElementSibling;
-                  if (nextSwatch?.classList.contains('swatch')) {
-                    applyPreviewToSwatch(nextSwatch, previewUrl);
+          // Wait a bit for DOM to stabilize after variant change
+          setTimeout(() => {
+            // Apply saved previews to swatches
+            let restoredCount = 0;
+            Object.entries(previewData.previews).forEach(([color, previewUrl]) => {
+              // Try multiple swatch selection methods
+              let swatchFound = false;
+              
+              // Method 1: Direct swatch element with data attributes
+              let swatch = document.querySelector(`.swatch[data-swatch-value="${color}"]`) ||
+                          document.querySelector(`.swatch[data-value="${color}"]`) ||
+                          document.querySelector(`.swatch[title="${color}"]`);
+              
+              if (swatch) {
+                applyPreviewToSwatch(swatch, previewUrl);
+                restoredCount++;
+                swatchFound = true;
+              }
+              
+              // Method 2: Find by radio input value
+              if (!swatchFound) {
+                const inputs = document.querySelectorAll('input[type="radio"][name*="Color"], input[type="radio"][name*="color"]');
+                for (const input of inputs) {
+                  if (input.value === color || input.value.toLowerCase() === color.toLowerCase()) {
+                    // Look for adjacent swatch in various configurations
+                    let targetSwatch = input.nextElementSibling;
+                    if (targetSwatch?.classList.contains('swatch')) {
+                      applyPreviewToSwatch(targetSwatch, previewUrl);
+                      restoredCount++;
+                      swatchFound = true;
+                      break;
+                    }
+                    
+                    // Sometimes swatch is wrapped in a label
+                    const label = input.closest('label');
+                    if (label) {
+                      targetSwatch = label.querySelector('.swatch');
+                      if (targetSwatch) {
+                        applyPreviewToSwatch(targetSwatch, previewUrl);
+                        restoredCount++;
+                        swatchFound = true;
+                        break;
+                      }
+                    }
+                  }
+                }
+              }
+              
+              // Method 3: Find by CSS background image containing the color
+              if (!swatchFound) {
+                const allSwatches = document.querySelectorAll('.swatch');
+                for (const sw of allSwatches) {
+                  const style = sw.getAttribute('style') || '';
+                  if (style.toLowerCase().includes(color.toLowerCase())) {
+                    applyPreviewToSwatch(sw, previewUrl);
                     restoredCount++;
                     break;
                   }
                 }
               }
-            } else {
-              applyPreviewToSwatch(swatch, previewUrl);
-              restoredCount++;
-            }
-          });
-          
-          console.log(`[ProductCustomizer] Restored ${restoredCount} variant swatches`);
+            });
+            
+            console.log(`[ProductCustomizer] Restored ${restoredCount} variant swatches`);
+            
+            // Double-check and reapply after a short delay to handle any theme updates
+            setTimeout(() => {
+              const customizedSwatches = document.querySelectorAll('[data-multi-preview="true"]');
+              console.log(`[ProductCustomizer] Verifying ${customizedSwatches.length} customized swatches`);
+              
+              customizedSwatches.forEach(swatch => {
+                const currentStyle = swatch.getAttribute('style');
+                if (!currentStyle || !currentStyle.includes('url(')) {
+                  // Swatch was reset, find the preview URL and reapply
+                  const swatchValue = swatch.dataset.swatchValue || swatch.dataset.value || swatch.title;
+                  if (swatchValue && previewData.previews[swatchValue]) {
+                    applyPreviewToSwatch(swatch, previewData.previews[swatchValue]);
+                  }
+                }
+              });
+            }, 500);
+            
+          }, 100); // Initial delay to let DOM settle
           
         } catch (error) {
           console.error('[ProductCustomizer] Error restoring swatches:', error);
@@ -606,28 +675,55 @@
         // Find all customized swatches
         const customizedSwatches = document.querySelectorAll('[data-multi-preview="true"]');
         
+        console.log(`[ProductCustomizer] Protecting ${customizedSwatches.length} customized swatches`);
+        
         customizedSwatches.forEach(swatch => {
           // Store current customized background
           const currentStyle = swatch.getAttribute('style');
           
-          // Use MutationObserver to prevent changes
+          // Create a more persistent observer that restores the style multiple times
+          let restoreCount = 0;
+          const maxRestores = 10;
+          
           const observer = new MutationObserver((mutations) => {
             mutations.forEach((mutation) => {
               if (mutation.attributeName === 'style' && 
                   swatch.getAttribute('style') !== currentStyle &&
-                  swatch.dataset.multiPreview === 'true') {
+                  swatch.dataset.multiPreview === 'true' &&
+                  restoreCount < maxRestores) {
                 // Theme tried to reset the swatch, restore our custom style
+                console.log('[ProductCustomizer] Restoring customized swatch style');
                 swatch.setAttribute('style', currentStyle);
+                restoreCount++;
+                
+                // Force a redraw to ensure the style sticks
+                swatch.offsetHeight; // Trigger reflow
               }
             });
           });
           
-          // Observe for a short time
+          // Observe for a longer time with more aggressive protection
           observer.observe(swatch, { attributes: true, attributeFilter: ['style'] });
           
-          // Stop observing after 2 seconds
-          setTimeout(() => observer.disconnect(), 2000);
+          // Also reapply the style periodically as a backup
+          const intervalId = setInterval(() => {
+            if (swatch.getAttribute('style') !== currentStyle && swatch.dataset.multiPreview === 'true') {
+              swatch.setAttribute('style', currentStyle);
+            }
+          }, 50);
+          
+          // Stop observing and intervals after 5 seconds
+          setTimeout(() => {
+            observer.disconnect();
+            clearInterval(intervalId);
+          }, 5000);
         });
+        
+        // Also try to restore swatches again after protection period
+        setTimeout(() => {
+          const currentVariantId = customizeBtn?.dataset.variantId || '{{ product.selected_or_first_available_variant.id }}';
+          restoreVariantSwatchesOnLoad(currentVariantId);
+        }, 1000);
       }
       
       // Helper function to get variant title by ID

--- a/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
+++ b/extensions/canvas-api-pdp/blocks/product_customizer_modern.liquid
@@ -255,7 +255,7 @@
                   }
                   
                   // First restore all cached variant swatches
-                  restoreVariantSwatchesOnLoad();
+                  restoreVariantSwatchesOnLoad(variantId);
                   
                   // Then generate preview for the current variant
                   if (typeof generateVariantPreviewWithCanvasState === 'function') {
@@ -328,7 +328,7 @@
                   }
                   
                   // First restore all cached variant swatches
-                  restoreVariantSwatchesOnLoad();
+                  restoreVariantSwatchesOnLoad(variantId);
                   
                   // Check if the function is available (script is loaded)
                   if (typeof generateVariantPreviewWithText === 'function') {
@@ -356,7 +356,7 @@
             
             // Always restore cached swatches if we have active customization
             if (hasActiveCustomization) {
-              restoreVariantSwatchesOnLoad();
+              restoreVariantSwatchesOnLoad(variantId);
             }
           } else {
             // Hide button if variant has no template
@@ -466,7 +466,7 @@
         
         // Restore variant swatches if we have global canvas state
         if (hasActiveCustomization) {
-          restoreVariantSwatchesOnLoad();
+          restoreVariantSwatchesOnLoad(initialVariantId);
         }
         
         // Clean up expired localStorage data
@@ -515,11 +515,14 @@
       }
       
       // Function to restore saved variant swatches on page load
-      function restoreVariantSwatchesOnLoad() {
+      function restoreVariantSwatchesOnLoad(variantId) {
         console.log('[ProductCustomizer] Checking for saved variant swatches');
         
+        // Use passed variantId or try to get current from button
+        const currentVariantId = variantId || customizeBtn?.dataset.variantId || '{{ product.selected_or_first_available_variant.id }}';
+        
         // Get current variant info to determine the pattern
-        const currentVariantTitle = getVariantTitleForId(initialVariantId);
+        const currentVariantTitle = getVariantTitleForId(currentVariantId);
         if (!currentVariantTitle) {
           console.log('[ProductCustomizer] Could not determine variant title');
           return;


### PR DESCRIPTION
## Summary
- Fixed variant swatches reverting to defaults when switching colors after full designer changes
- Improved swatch restoration reliability with better DOM selection methods
- Added aggressive protection mechanisms to prevent theme from resetting customized swatches
- Ensures persistent visual experience across all variant interactions

## Problem
When a user makes changes in the full designer and clicks "Done":
1. The global canvas state is saved to localStorage ✅
2. Variant swatches are updated dynamically ✅
3. Everything works correctly until user clicks another color swatch ❌
4. Swatches reset to original images despite having cached previews
5. Restoration was inconsistent (worked ~1 in 10 times)

## Solution
1. **Caching approach** instead of regeneration:
   - Store generated preview URLs in localStorage by pattern
   - Restore from cache on page load and variant changes
   - Much faster than regenerating all previews

2. **Improved DOM selection**:
   - Multiple methods to find swatches (data attributes, radio inputs, CSS)
   - Case-insensitive matching
   - Support for swatches within labels

3. **Better timing and protection**:
   - 100ms delay for DOM stabilization
   - MutationObserver with up to 10 restore attempts
   - Periodic style checks every 50ms for 5 seconds
   - Verification pass after 500ms

4. **Event handling improvements**:
   - Immediate swatch restoration on variant change events
   - Protection before and after variant switches
   - Works with multiple event patterns

## Test Plan
1. Go to a product page with multiple color variants
2. Click "Customize this product" 
3. Click "Edit using Design Tool" to open full designer
4. Make changes (change background, text colors, etc.)
5. Click "Done" in full designer
6. Verify all variant swatches update with new design ✅
7. **Click different color swatches multiple times**
8. Verify swatches maintain customized previews (not reset to defaults) ✅
9. **Refresh the page**
10. Verify variant swatches still show customized design ✅
11. Click color swatches again to verify persistence ✅

🤖 Generated with [Claude Code](https://claude.ai/code)