### PR TITLE
feat: Add plan for blur transition during product image generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -991,6 +991,63 @@ Modern Shopify themes like Horizon use DOM manipulation that can reset custom va
 - **Base64 Detection**: Accurately identifies custom swatches vs theme defaults
 - **Temporary Observers**: Balance between protection and performance
 
+## Product Image Selection System
+
+### Overview
+The `findMainProductImage()` method in `product-customizer-modal.js` provides a reliable way to locate the main product image across different Shopify themes. The method is organized by theme type for clarity and performance.
+
+### Theme-Specific Selectors
+
+The method uses a cascading approach, checking theme-specific selectors in order:
+
+1. **Horizon 2025 Themes** (Tinker, etc.):
+   ```javascript
+   // Custom elements used by modern Horizon themes
+   'media-gallery img:first-of-type'
+   'media-gallery slideshow-component img:first-of-type'
+   'slideshow-component img.selected'
+   'slideshow-component img[aria-selected="true"]'
+   ```
+
+2. **Dawn-Based Themes** (Dawn, Craft, Sense, etc.):
+   ```javascript
+   // Data attributes and BEM-style classes
+   '.product__media img[data-media-type="image"]:not(.zoom-image)'
+   '.product__main-photos img.main-product-image'
+   '.product__image img.product__img'
+   'slideshow-wrapper img.slideshow__slide-image--active'
+   ```
+
+3. **Legacy/Generic Themes**:
+   ```javascript
+   // Older themes and custom implementations
+   '.media-gallery img:first-of-type'  // Class-based media gallery
+   '.product-media img:first-of-type'
+   '.product__media--featured img'
+   '[data-product-featured-image]'
+   '.product-gallery img:first-of-type'
+   ```
+
+4. **Final Fallback**:
+   - Calls `findAnyLargeProductImage()` helper method
+   - Searches for any product image ≥200px that's not a thumbnail
+   - Excludes images in recommendation sections
+
+### Usage
+
+The method is used in several places:
+
+1. **`updateMainProductImage()`**: Updates the product image with customization preview
+2. **`updateMainProductImageDirectly()`**: Direct image update without stored references
+3. **`storeOriginalProductImage()`**: Stores original images before customization
+
+### Benefits of This Approach
+
+- **Performance**: Faster by checking only relevant selectors per theme
+- **Clarity**: Clear organization shows which selectors work with which themes
+- **Maintainability**: Easy to update selectors for specific theme types
+- **Reliability**: Fallback ensures an image is found even in custom themes
+
 # important-instruction-reminders
 Do what has been asked; nothing more, nothing less.
 NEVER create files unless they're absolutely necessary for achieving your goal.

--- a/PLAN_BLUR_PRODUCT_IMAGE_DURING_GENERATION.md
+++ b/PLAN_BLUR_PRODUCT_IMAGE_DURING_GENERATION.md
@@ -1,0 +1,83 @@
+# Plan: Blur Product Image During Konva Generation
+
+## Problem
+When switching variants with customizations, users see the default (non-customized) product image for ~1 second while Konva generates the new preview.
+
+## Solution: Blur/Fade Transition
+
+### Implementation Steps
+
+1. **Add CSS Transitions** to `product-customizer-modal.js`:
+```css
+.product-image-transitioning {
+  transition: opacity 0.3s ease, filter 0.3s ease;
+  opacity: 0.3;
+  filter: blur(10px);
+}
+```
+
+2. **Modify `updateProductImageForVariant`**:
+```javascript
+async updateProductImageForVariant(variantId) {
+  // 1. Immediately blur the current image
+  const mainImage = this.findMainProductImage();
+  if (mainImage) {
+    mainImage.classList.add('product-image-transitioning');
+  }
+  
+  // 2. Check cache first (existing code)
+  const cachedPreview = PreviewCache.get(variantId);
+  if (cachedPreview) {
+    // Smooth transition to cached image
+    this.transitionToNewImage(mainImage, cachedPreview);
+    return;
+  }
+  
+  // 3. Generate preview (existing code)
+  // ... konva generation ...
+  
+  // 4. Smooth transition when ready
+  if (preview) {
+    this.transitionToNewImage(mainImage, preview);
+  }
+}
+
+transitionToNewImage(imageElement, newSrc) {
+  if (!imageElement) return;
+  
+  // Preload the new image
+  const tempImg = new Image();
+  tempImg.onload = () => {
+    imageElement.src = newSrc;
+    // Remove blur after image loads
+    setTimeout(() => {
+      imageElement.classList.remove('product-image-transitioning');
+    }, 50);
+  };
+  tempImg.src = newSrc;
+}
+```
+
+3. **Optional Enhancement**: Show last customized preview
+```javascript
+// Store last preview regardless of variant
+localStorage.setItem('last_customized_preview', preview);
+
+// On variant change, show last preview immediately (blurred)
+const lastPreview = localStorage.getItem('last_customized_preview');
+if (lastPreview && mainImage) {
+  mainImage.src = lastPreview;
+  mainImage.classList.add('product-image-transitioning');
+}
+```
+
+### Benefits
+- Immediate visual feedback
+- No jarring switch from customized → default → customized
+- Smooth transitions
+- Works with existing cache system
+
+### Timeline
+- CSS injection: Immediate on modal init
+- Blur effect: < 50ms after variant change
+- Total perceived delay: Reduced from 1s to ~300ms transition

--- a/PLAN_UPDATE_PRODUCT_IMAGE_ON_VARIANT_CHANGE.md
+++ b/PLAN_UPDATE_PRODUCT_IMAGE_ON_VARIANT_CHANGE.md
@@ -1,0 +1,299 @@
+# Plan: Update Product Image on Variant Change
+
+## Feature Overview
+
+### Goal
+Automatically update the main product image with customizations when users switch between color variants (e.g., Green to Purple), ensuring the product display always reflects the current customizations.
+
+### Context
+- Users can customize products with text via the ProductCustomizerModal
+- Customizations are saved in localStorage as `customization_global_text`
+- When switching variants, the product image should show the new variant with applied customizations
+- We have three reliable detection methods from the swatch protection system
+
+## Technical Architecture
+
+### Detection Methods to Leverage
+1. **URL Monitoring** (Primary)
+   - Polls every 100ms for `?variant=` parameter changes
+   - Most reliable method across all themes
+   
+2. **Click Event Capture** (Secondary)
+   - Listens for clicks on color radio inputs
+   - Provides immediate feedback
+   
+3. **MutationObserver** (Tertiary)
+   - Watches variant picker elements for DOM changes
+   - Handles theme-specific DOM morphing
+
+### Integration Points
+
+```javascript
+// Existing swatch protection handleVariantChange
+const handleVariantChange = function(event) {
+  // ... existing swatch protection logic ...
+  
+  // NEW: Check for customizations and update product image
+  updateProductImageIfCustomized(variantId);
+}
+```
+
+## Implementation Details
+
+### 1. Global Modal Registry
+
+Create a registry to track active ProductCustomizerModal instances:
+
+```javascript
+// Add to ProductCustomizerModal class
+class ProductCustomizerModal {
+  static activeInstance = null;
+  
+  constructor(options) {
+    // ... existing code ...
+    ProductCustomizerModal.activeInstance = this;
+  }
+  
+  close() {
+    // ... existing code ...
+    if (ProductCustomizerModal.activeInstance === this) {
+      ProductCustomizerModal.activeInstance = null;
+    }
+  }
+}
+```
+
+### 2. Enhanced Variant Change Handler
+
+Add product image update logic to the global swatch protection system:
+
+```javascript
+// In the global IIFE after handleVariantChange
+const updateProductImageIfCustomized = (variantId) => {
+  // Check if we have saved customizations
+  const savedTextState = localStorage.getItem('customization_global_text');
+  if (!savedTextState) return;
+  
+  // Check if we have an active modal instance
+  const modal = window.ProductCustomizerModal?.activeInstance;
+  if (!modal) return;
+  
+  // Debounce to prevent rapid updates
+  clearTimeout(window.productImageUpdateTimer);
+  window.productImageUpdateTimer = setTimeout(() => {
+    modal.updateProductImageForVariant(variantId);
+  }, 200);
+};
+```
+
+### 3. New Modal Method: updateProductImageForVariant
+
+```javascript
+async updateProductImageForVariant(variantId) {
+  console.log('[ProductCustomizer] Updating product image for variant:', variantId);
+  
+  // Get the template for this variant
+  const templateId = this.getTemplateIdForVariant(variantId);
+  if (!templateId) return;
+  
+  // Create a temporary renderer to generate preview
+  const tempRenderer = new CanvasTextRenderer();
+  await tempRenderer.loadTemplate(templateId);
+  
+  // Apply saved text customizations
+  const savedTextState = this.loadGlobalTextState();
+  if (savedTextState) {
+    tempRenderer.applyTextUpdates(savedTextState);
+  }
+  
+  // Generate preview
+  const preview = await tempRenderer.generatePreview();
+  
+  // Update main product image
+  if (preview) {
+    this.updateMainProductImage(preview);
+  }
+  
+  // Cleanup
+  tempRenderer.destroy();
+}
+```
+
+### 4. Helper Method: getTemplateIdForVariant
+
+```javascript
+getTemplateIdForVariant(variantId) {
+  // Try multiple methods to find template ID
+  
+  // Method 1: Check current window.productData
+  if (window.productData?.variants) {
+    const variant = window.productData.variants.find(v => v.id == variantId);
+    if (variant?.metafields?.custom_designer?.template_id) {
+      return variant.metafields.custom_designer.template_id;
+    }
+  }
+  
+  // Method 2: Query DOM for variant input
+  const variantInput = document.querySelector(`input[data-variant-id="${variantId}"]`);
+  if (variantInput?.dataset.templateId) {
+    return variantInput.dataset.templateId;
+  }
+  
+  // Method 3: Make API call if needed
+  // ... implement if other methods fail ...
+  
+  return null;
+}
+```
+
+## Performance Considerations
+
+### Caching Strategy
+```javascript
+// Cache generated previews to avoid regeneration
+class PreviewCache {
+  static cache = new Map();
+  static maxSize = 10;
+  
+  static set(variantId, preview) {
+    // LRU cache implementation
+    if (this.cache.size >= this.maxSize) {
+      const firstKey = this.cache.keys().next().value;
+      this.cache.delete(firstKey);
+    }
+    this.cache.set(variantId, preview);
+  }
+  
+  static get(variantId) {
+    const preview = this.cache.get(variantId);
+    if (preview) {
+      // Move to end (most recently used)
+      this.cache.delete(variantId);
+      this.cache.set(variantId, preview);
+    }
+    return preview;
+  }
+}
+```
+
+### Debouncing
+- Variant change events: 200ms debounce
+- Preview generation: Use requestAnimationFrame
+- Cache previews to avoid regeneration
+
+## Edge Cases and Handling
+
+### 1. Dual-Sided Templates
+```javascript
+// Handle front/back preview for dual-sided templates
+if (this.isDualSided) {
+  // Generate front preview
+  const frontPreview = await this.generateVariantPreview('front');
+  this.updateMainProductImage(frontPreview);
+  
+  // Optionally update back preview if visible
+  if (this.isShowingBack) {
+    const backPreview = await this.generateVariantPreview('back');
+    this.updateMainProductImage(backPreview, true);
+  }
+}
+```
+
+### 2. No Customizations
+- Check for saved state before attempting updates
+- Restore original product images if customizations are cleared
+
+### 3. Modal Not Yet Opened
+- Only update if modal has been opened at least once
+- Track initialization state
+
+### 4. Rapid Variant Switching
+- Implement debouncing (200ms)
+- Cancel pending preview generations
+- Use preview cache
+
+## Testing Scenarios
+
+### Basic Flow
+1. Open product page with customizable variants
+2. Click "Customize this design"
+3. Add text customizations
+4. Close modal
+5. Switch from Green to Purple variant
+6. **Expected**: Main product image updates to show Purple variant with text
+
+### Edge Case Testing
+
+#### Test 1: Rapid Switching
+1. Add customizations
+2. Rapidly switch between 3+ color variants
+3. **Expected**: Final variant shows correct preview, no flashing
+
+#### Test 2: Dual-Sided Template
+1. Customize both front and back of a dual-sided product
+2. Close modal
+3. Switch variants
+4. **Expected**: Front image updates with customizations
+
+#### Test 3: Clear Customizations
+1. Add customizations
+2. Clear all text (empty inputs)
+3. Save and close
+4. Switch variants
+5. **Expected**: Original product images restored
+
+#### Test 4: Multiple Products
+1. Customize Product A
+2. Navigate to Product B
+3. Customize Product B
+4. Switch variants on Product B
+5. **Expected**: Only Product B images update
+
+### Performance Testing
+- Monitor console for excessive API calls
+- Check preview generation time
+- Verify cache is working (subsequent switches should be faster)
+- Ensure no memory leaks with repeated switching
+
+## Implementation Steps
+
+1. **Create feature branch**: `feat/update-product-image-on-variant-change`
+
+2. **Modify product-customizer-modal.js**:
+   - Add static activeInstance property
+   - Implement updateProductImageForVariant method
+   - Add preview caching
+   - Enhance global swatch protection system
+
+3. **Test thoroughly**:
+   - All test scenarios above
+   - Cross-browser testing
+   - Mobile responsiveness
+
+4. **Optimize**:
+   - Implement preview cache
+   - Add performance logging
+   - Fine-tune debounce timings
+
+5. **Document**:
+   - Update CLAUDE.md with new feature
+   - Add inline code comments
+   - Create user-facing documentation if needed
+
+## Success Criteria
+
+- ✅ Product images update automatically on variant change when customizations exist
+- ✅ Updates are smooth and debounced (no flashing)
+- ✅ Works with all three detection methods
+- ✅ Handles dual-sided templates correctly
+- ✅ Performance is acceptable (< 500ms update time)
+- ✅ No memory leaks or excessive API calls
+- ✅ Graceful handling of edge cases
+
+## Future Enhancements
+
+1. **Batch Preview Generation**: Pre-generate previews for all variants when customizing
+2. **Smart Caching**: Persist preview cache in localStorage
+3. **Progressive Loading**: Show low-res preview immediately, update with high-res
+4. **Animation**: Smooth transition between variant images
+5. **Multi-Image Support**: Update all product images (gallery, thumbnails)

--- a/horizon-theme-examples/assets/media-gallery.js
+++ b/horizon-theme-examples/assets/media-gallery.js
@@ -1,0 +1,84 @@
+import { Component } from '@theme/component';
+import { ThemeEvents, VariantUpdateEvent, ZoomMediaSelectedEvent } from '@theme/events';
+
+/**
+ * A custom element that renders a media gallery.
+ *
+ * @typedef {object} Refs
+ * @property {import('./zoom-dialog').ZoomDialog} [zoomDialogComponent] - The zoom dialog component.
+ * @property {import('./slideshow').Slideshow} [slideshow] - The slideshow component.
+ * @property {HTMLElement[]} [media] - The media elements.
+ *
+ * @extends Component<Refs>
+ */
+export class MediaGallery extends Component {
+  connectedCallback() {
+    super.connectedCallback();
+
+    const { signal } = this.#controller;
+    const target = this.closest('.shopify-section, dialog');
+
+    target?.addEventListener(ThemeEvents.variantUpdate, this.#handleVariantUpdate, { signal });
+    this.refs.zoomDialogComponent?.addEventListener(ThemeEvents.zoomMediaSelected, this.#handleZoomMediaSelected, {
+      signal,
+    });
+  }
+
+  #controller = new AbortController();
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    this.#controller.abort();
+  }
+
+  /**
+   * Handles a variant update event by replacing the current media gallery with a new one.
+   *
+   * @param {VariantUpdateEvent} event - The variant update event.
+   */
+  #handleVariantUpdate = (event) => {
+    const source = event.detail.data.html;
+
+    if (!source) return;
+    const newMediaGallery = source.querySelector('media-gallery');
+
+    if (!newMediaGallery) return;
+
+    this.replaceWith(newMediaGallery);
+  };
+
+  /**
+   * Handles the 'zoom-media:selected' event.
+   * @param {ZoomMediaSelectedEvent} event - The zoom-media:selected event.
+   */
+  #handleZoomMediaSelected = async (event) => {
+    this.slideshow?.select(event.detail.index, undefined, { animate: false });
+  };
+
+  /**
+   * Zooms the media gallery.
+   *
+   * @param {number} index - The index of the media to zoom.
+   * @param {PointerEvent} event - The pointer event.
+   */
+  zoom(index, event) {
+    this.refs.zoomDialogComponent?.open(index, event);
+  }
+
+  get slideshow() {
+    return this.refs.slideshow;
+  }
+
+  get media() {
+    return this.refs.media;
+  }
+
+  get presentation() {
+    return this.dataset.presentation;
+  }
+}
+
+if (!customElements.get('media-gallery')) {
+  customElements.define('media-gallery', MediaGallery);
+}

--- a/horizon-theme-examples/blocks/_product-card-gallery.liquid
+++ b/horizon-theme-examples/blocks/_product-card-gallery.liquid
@@ -1,0 +1,170 @@
+
+
+{% capture children %}
+  {% unless block.settings.product == blank %}
+    {% render 'product-card-badges', product: block.settings.product %}
+    {%  if settings.quick_add or settings.mobile_quick_add %}
+      {% render 'quick-add', product: block.settings.product, section_id: section.id %}
+    {% endif %}
+  {% endunless %}
+{% endcapture %}
+
+{% render 'card-gallery', children: children %}
+
+{% # Title and price for the zoomed out grid view %}
+<div class="product-grid-view-zoom-out--details">
+  {% if block.settings.product == blank %}
+    <h3 class="h4">{{ 'content.product_card_placeholder' | t }}</h3>
+  {% else %}
+    <h3 class="h4">{{ block.settings.product.title }}</h3>
+    <div class="h6">
+      <product-price data-product-id="{{ block.settings.product.id }}">
+        {% render 'price', product_resource: block.settings.product, show_unit_price: false %}
+      </product-price>
+    </div>
+  {% endif %}
+</div>
+
+{% schema %}
+{
+  "name": "t:names.product_image",
+  "tag": null,
+  "settings": [
+    {
+      "type": "product",
+      "id": "product",
+      "label": "t:settings.product"
+    },
+    {
+      "type": "select",
+      "id": "image_ratio",
+      "options": [
+        {
+          "value": "adapt",
+          "label": "t:options.auto"
+        },
+        {
+          "value": "portrait",
+          "label": "t:options.portrait"
+        },
+        {
+          "value": "square",
+          "label": "t:options.square"
+        },
+        {
+          "value": "landscape",
+          "label": "t:options.landscape"
+        }
+      ],
+      "default": "portrait",
+      "label": "t:settings.aspect_ratio",
+      "info": "t:info.aspect_ratio_adjusted"
+    },
+    {
+      "type": "header",
+      "content": "t:content.borders"
+    },
+    {
+      "type": "select",
+      "id": "border",
+      "label": "t:settings.style",
+      "options": [
+        {
+          "value": "none",
+          "label": "t:options.none"
+        },
+        {
+          "value": "solid",
+          "label": "t:options.solid"
+        }
+      ],
+      "default": "none"
+    },
+    {
+      "type": "range",
+      "id": "border_width",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px",
+      "label": "t:settings.thickness",
+      "default": 1,
+      "visible_if": "{{ block.settings.border != 'none' }}"
+    },
+    {
+      "type": "range",
+      "id": "border_opacity",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%",
+      "label": "t:settings.opacity",
+      "default": 100,
+      "visible_if": "{{ block.settings.border != 'none' }}"
+    },
+    {
+      "type": "range",
+      "id": "border_radius",
+      "label": "t:settings.border_radius",
+      "min": 0,
+      "max": 32,
+      "step": 1,
+      "unit": "px",
+      "default": 0
+    },
+    {
+      "type": "header",
+      "content": "t:content.padding"
+    },
+    {
+      "type": "range",
+      "id": "padding-block-start",
+      "label": "t:settings.top",
+      "min": 0,
+      "max": 50,
+      "step": 1,
+      "unit": "px",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "padding-block-end",
+      "label": "t:settings.bottom",
+      "min": 0,
+      "max": 50,
+      "step": 1,
+      "unit": "px",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "padding-inline-start",
+      "label": "t:settings.left",
+      "min": 0,
+      "max": 50,
+      "step": 1,
+      "unit": "px",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "padding-inline-end",
+      "label": "t:settings.right",
+      "min": 0,
+      "max": 50,
+      "step": 1,
+      "unit": "px",
+      "default": 0
+    }
+  ],
+  "presets": [
+    {
+      "name": "t:names.product_card_media",
+      "category": "t:categories.product",
+      "settings": {
+        "product": "{{ closest.product }}"
+      }
+    }
+  ]
+}
+{% endschema %}

--- a/horizon-theme-examples/blocks/_product-media.gallery.liquid
+++ b/horizon-theme-examples/blocks/_product-media.gallery.liquid
@@ -1,0 +1,798 @@
+
+
+{%- if block.settings.zoom -%}
+  <script
+    src="{{ 'zoom-dialog.js' | asset_url }}"
+    type="module"
+  ></script>
+{%- endif -%}
+
+{%- liquid
+  assign selected_product = block.settings.product
+  assign selected_variant_media = selected_product.selected_or_first_available_variant.featured_media
+  assign first_3d_model = selected_product.media | where: 'media_type', 'model' | first
+
+  if block.settings.hide_variants
+    assign variant_images = product.images | where: 'attached_to_variant?', true | map: 'src'
+  endif
+
+  if block.settings.slideshow_controls_style == 'thumbnails'
+    assign controls_on_media = false
+  else
+    assign controls_on_media = true
+  endif
+
+  assign render_slideshow_controls = false
+
+  if block.settings.media_presentation == 'carousel' or block.settings.slideshow_controls_style == block.settings.slideshow_mobile_controls_style
+    assign render_slideshow_controls = true
+  endif
+
+  assign render_mobile_slideshow_controls = false
+
+  if block.settings.slideshow_controls_style != block.settings.slideshow_mobile_controls_style
+    assign slideshow_controls_class = 'mobile:hidden'
+
+    if block.settings.slideshow_mobile_controls_style != 'hint'
+      assign render_mobile_slideshow_controls = true
+    endif
+  endif
+
+  assign slideshow_controls_style = block.settings.slideshow_controls_style
+  # Use a counter instead of dots when there are many images to avoid cropping/overflow.
+  if slideshow_controls_style == 'dots' and selected_product.media.size > 15
+    assign slideshow_controls_style = 'counter'
+  endif
+
+  assign render_slideshow_arrows = false
+
+  if selected_product.media.size <= 1
+    assign slideshow_class = 'product-media-gallery__slideshow--single-media slideshow--single-media'
+  else
+    assign slideshow_class = ''
+
+    if block.settings.media_presentation == 'carousel'
+      assign render_slideshow_arrows = true
+    endif
+  endif
+
+  if slideshow_controls_style == 'thumbnails'
+    assign pagination_position = block.settings.thumbnail_position
+  else
+    assign pagination_position = 'center'
+  endif
+
+  # correct discrepancy between position settings for thumbnails and other controls
+  if pagination_position == 'bottom'
+    assign pagination_position = 'center'
+  endif
+
+  assign icons_position = 'center'
+
+  # Put the icons on the opposite side of the pagination controls
+  if block.settings.slideshow_controls_position == 'on_media'
+    if pagination_position == 'left'
+      assign icons_position = 'right'
+    elsif pagination_position == 'right'
+      assign icons_position = 'left'
+    endif
+  endif
+-%}
+
+{%- liquid
+  assign sorted_media = '' | split: ','
+  if selected_variant_media
+    assign sorted_media = sorted_media | concat: selected_product.media | where: 'id', selected_variant_media.id
+
+    for media in selected_product.media
+      if block.settings.hide_variants and variant_images contains media.src and sorted_media.size > 0
+        continue
+      endif
+
+      if media.id != selected_variant_media.id
+        assign found_media = selected_product.media | where: 'id', media.id
+        assign sorted_media = sorted_media | concat: found_media
+      endif
+    endfor
+  else
+    assign sorted_media = selected_product.media
+  endif
+  assign has_image_drop = sorted_media | has: 'media_type', 'image'
+-%}
+{%- if has_image_drop -%}
+  <script
+    src="{{ 'drag-zoom-wrapper.js' | asset_url }}"
+    type="module"
+  ></script>
+{%- endif -%}
+
+{% style %}
+  {% unless block.settings.aspect_ratio == 'adapt' %}
+    .product-media-container {
+      --media-preview-ratio: {{ block.settings.aspect_ratio }};
+    }
+  {% endunless %}
+{% endstyle %}
+
+<media-gallery
+  class="
+    spacing-style
+    sticky-content
+    {% if block.settings.media_presentation == 'grid' %}
+      media-gallery--{{ block.settings.media_columns }}-column
+      {% if block.settings.media_columns == "two" and block.settings.large_first_image%}media-gallery--large-first-image{% endif %}
+    {% endif %}
+    media-gallery--{{ block.settings.media_presentation }}
+    {% if block.settings.slideshow_mobile_controls_style == 'hint' %}
+      media-gallery--hint
+    {% endif %}
+    {% if block.settings.extend_media %}
+      media-gallery--extend
+    {% endif %}
+  "
+  style="{% render 'spacing-style', settings: block.settings %} --thumbnail-width: {{ block.settings.thumbnail_width }}px; --media-radius: {{ block.settings.media_radius }}px;{% if block.settings.icons_style contains 'large' %} --slideshow-icon-padding: 0;{% endif %}--image-gap: {{ block.settings.image_gap }}px;"
+  data-presentation="{{ block.settings.media_presentation }}"
+  {{ block.shopify_attributes }}
+>
+  {% capture slides %}
+    {% for media in sorted_media %}
+      {% capture children %}
+        {%- render 'product-media', media: media -%}
+      {% endcapture %}
+      {% capture class %}
+        product-media-container product-media-container--{{ media.media_type }}{% if block.settings.constrain_to_viewport %} constrain-height{% endif %}{% if block.settings.aspect_ratio != 'adapt' %} media-fit{% endif %}{% if block.settings.zoom %} product-media-container--zoomable{% endif %}
+      {% endcapture %}
+      {% if block.settings.aspect_ratio == 'adapt' %}
+        {% capture style %}
+          --media-preview-ratio: {{ media.preview_image.aspect_ratio | default: 1.0 }};
+        {% endcapture %}
+      {% endif %}
+      {% if block.settings.zoom and media.media_type == 'model' %}
+        {%- capture attributes -%}"{% if settings.transition_to_main_product and forloop.first %} data-view-transition-type="product-image-transition"{% endif %}{% endcapture -%}
+      {% elsif block.settings.zoom %}
+        {%- capture attributes -%}on:click="#zoom-dialog-{{ block.id }}/open/{{ forloop.index0 }}"{% if settings.transition_to_main_product and forloop.first %} data-view-transition-type="product-image-transition"{% endif %}{% endcapture -%}
+      {% endif %}
+
+      {% render 'slideshow-slide',
+        index: forloop.index,
+        children: children,
+        class: class,
+        style: style,
+        attributes: attributes,
+      %}
+    {% endfor %}
+  {% endcapture %}
+
+  {% if sorted_media.size > 1 %}
+    {% capture controls %}
+      {% if render_slideshow_controls %}
+        {%- render 'slideshow-controls',
+          class: slideshow_controls_class,
+          style: slideshow_controls_style,
+          item_count: sorted_media.size,
+          thumbnails: sorted_media,
+          controls_on_media: controls_on_media,
+          pagination_position: pagination_position,
+          aspect_ratio: block.settings.aspect_ratio
+        -%}
+      {% endif %}
+
+      {% if render_mobile_slideshow_controls %}
+        {%- render 'slideshow-controls',
+          class: 'desktop:hidden media-gallery__mobile-controls',
+          style: block.settings.slideshow_mobile_controls_style,
+          item_count: sorted_media.size,
+          controls_on_media: true,
+          pagination_position: 'center',
+        -%}
+      {% endif %}
+    {% endcapture %}
+  {% endif %}
+
+  {% if render_slideshow_arrows %}
+    {% capture slideshow_arrows %}
+      {% render 'slideshow-arrows', class: 'mobile:hidden', icon_style: block.settings.icons_style, icon_shape: settings.icons_shape %}
+    {% endcapture %}
+  {% endif %}
+
+  {% render 'slideshow',
+    ref: 'slideshow',
+    class: slideshow_class,
+    slides: slides,
+    slide_count: sorted_media.size,
+    slideshow_arrows: slideshow_arrows,
+    arrows_position: icons_position,
+    controls: controls
+  %}
+
+  {% if block.settings.media_presentation == 'grid' %}
+    <ul
+      class="media-gallery__grid list-unstyled"
+      data-testid="media-gallery-grid"
+    >
+      {% for media in sorted_media %}
+        <li
+          ref="media[]"
+          class="
+            product-media-container
+            product-media-container--{{ media.media_type }}
+            {%- if block.settings.constrain_to_viewport %} constrain-height{% endif %}
+            {%- if block.settings.aspect_ratio != 'adapt' %} media-fit{% endif %}
+          "
+          style="{% if block.settings.aspect_ratio == 'adapt' %} --media-preview-ratio: {{ media.preview_image.aspect_ratio | default: 1.0 }};{% endif %}"
+          {% if settings.transition_to_main_product and forloop.first %}
+            data-view-transition-type="product-image-transition"
+          {% endif %}
+        >
+          {%- if block.settings.zoom and media.media_type == 'image' -%}
+            <button
+              type="button"
+              class="button button-unstyled product-media-container__zoom-button"
+              aria-label="{{ 'actions.zoom' | t }}"
+              on:click="/zoom/{{ forloop.index0 }}"
+            >
+              <span class="visually-hidden">{{ 'actions.open_image_in_full_screen' | t }}</span>
+            </button>
+          {%- endif -%}
+          {%- render 'product-media', media: media -%}
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
+  {%- if block.settings.zoom -%}
+    <zoom-dialog
+      ref="zoomDialogComponent"
+      id="zoom-dialog-{{ block.id }}"
+    >
+      <dialog
+        ref="dialog"
+        on:keydown="/handleKeyDown"
+        scroll-lock
+      >
+        <button
+          type="button"
+          class="button button-unstyled close-button dialog-zoomed-gallery__close-button"
+          aria-label="{{ 'actions.close' | t }}"
+          on:click="/close"
+        >
+          <span class="visually-hidden">{{ 'actions.close' | t }}</span>
+          {{ 'icon-close.svg' | inline_asset_content }}
+        </button>
+        <div class="dialog-thumbnails-list-container">
+          <scroll-hint
+            class="dialog-thumbnails-list list-unstyled"
+            ref="thumbnails"
+          >
+            {% if sorted_media.size > 1 %}
+              {%- for media in sorted_media -%}
+                {% liquid
+                  assign aspect_ratio = block.settings.aspect_ratio
+                  if block.settings.aspect_ratio == 'adapt'
+                    assign aspect_ratio = media.preview_image.aspect_ratio | default: 1.0
+                  endif
+                %}
+                <button
+                  type="button"
+                  class="button button-unstyled dialog-thumbnails-list__thumbnail"
+                  aria-label="{{ 'accessibility.scroll_to' | t: title: media.alt | default: media.media_type }}"
+                  on:click="/handleThumbnailClick/{{ forloop.index0 }}"
+                  on:pointerenter="/handleThumbnailPointerEnter/{{ forloop.index0 }}"
+                  style="--aspect-ratio: {{ aspect_ratio }}; --gallery-aspect-ratio: {{ aspect_ratio }};"
+                  {% if forloop.first %}
+                    aria-selected="true"
+                  {% endif %}
+                >
+                  {{
+                    media.preview_image
+                    | image_url: width: 1024
+                    | image_tag:
+                      loading: 'lazy',
+                      sizes: 'auto, 110, (min-width: 750px) 160',
+                      widths: '300, 375, 450, 525, 600, 675, 750, 768, 850, 900, 1024',
+                      alt: media.alt
+                    | escape
+                  }}
+                </button>
+              {%- endfor -%}
+            {% endif %}
+          </scroll-hint>
+        </div>
+        <ul
+          class="dialog-zoomed-gallery list-unstyled"
+        >
+          {%- for media in sorted_media -%}
+            <li
+              id="product-{{ media.id}}-{{ forloop.index }}"
+              class="
+                product-media-container
+                product-media-container--{{ media.media_type }}
+                {% if block.settings.constrain_to_viewport %} constrain-height{% endif %}
+                {% if block.settings.aspect_ratio != 'adapt' %} media-fit{% endif %}
+                {% if media.media_type == 'image' %} product-media-container--zoomable{% endif %}
+              "
+              style="{% if block.settings.aspect_ratio == 'adapt' %} --media-preview-ratio: {{ media.preview_image.aspect_ratio | default: 1.0 }};{% endif %}"
+              ref="media[]"
+              {% if media.media_type == 'image' %}
+                on:click="/close"
+              {% endif %}
+            >
+              {% if media.media_type == 'image' %}
+                <drag-zoom-wrapper class="product-media__drag-zoom-wrapper">
+                  {%- render 'product-media', media: media -%}
+                </drag-zoom-wrapper>
+              {% else %}
+                {%- render 'product-media', media: media -%}
+              {% endif %}
+            </li>
+          {%- endfor -%}
+        </ul>
+      </dialog>
+    </zoom-dialog>
+  {%- endif -%}
+
+  {%- if first_3d_model -%}
+    <link
+      id="ModelViewerStyle"
+      rel="stylesheet"
+      href="https://cdn.shopify.com/shopifycloud/model-viewer-ui/assets/v1.0/model-viewer-ui.css"
+      media="print"
+      onload="this.media='all'"
+    >
+    <script>
+      window.ProductModel = {
+        loadShopifyXR() {
+          Shopify.loadFeatures([
+            {
+              name: 'shopify-xr',
+              version: '1.0',
+              onLoad: this.setupShopifyXR.bind(this),
+            },
+          ]);
+        },
+
+        setupShopifyXR(errors) {
+          if (errors) return;
+
+          if (!window.ShopifyXR) {
+            document.addEventListener('shopify_xr_initialized', () => this.setupShopifyXR());
+            return;
+          }
+
+          document.querySelectorAll('[id^="ProductModelJSON-"]').forEach((modelJSON) => {
+            window.ShopifyXR.addModels(JSON.parse(modelJSON.textContent));
+            modelJSON.remove();
+          });
+          window.ShopifyXR.setupXRElements();
+        },
+      };
+
+      window.ProductModel.loadShopifyXR();
+    </script>
+  {%- endif -%}
+</media-gallery>
+
+{% stylesheet %}
+  .dialog-zoomed-gallery {
+    cursor: zoom-out;
+  }
+
+  .dialog--preloading {
+    opacity: 0;
+  }
+
+  .product-media__drag-zoom-wrapper {
+    aspect-ratio: inherit;
+    min-height: inherit;
+    min-width: inherit;
+    display: inherit;
+    flex: inherit;
+  }
+
+  @media screen and (width < 750px) {
+    .dialog-zoomed-gallery {
+      /* Prevent scroll wheel or swipe scrolling */
+      overscroll-behavior: none;
+      scrollbar-width: none;
+      display: flex;
+      scroll-snap-type: x mandatory;
+      overflow-x: hidden;
+      scroll-behavior: smooth;
+      height: 100%;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+
+    .dialog-zoomed-gallery .product-media-container {
+      flex: 0 0 100%;
+      scroll-snap-align: start;
+      position: relative;
+    }
+
+    .dialog-zoomed-gallery .product-media-container--image .product-media {
+      aspect-ratio: auto;
+      height: 100%;
+      width: 100%;
+      overflow: hidden;
+    }
+
+    .dialog-zoomed-gallery .product-media-container--video,
+    .dialog-zoomed-gallery .product-media-container--external_video {
+      align-content: center;
+    }
+
+    .dialog-zoomed-gallery
+      :is(.product-media-container--video, .product-media-container--external_video, .product-media-container--model)
+      .product-media {
+      aspect-ratio: auto;
+      align-items: center;
+      height: 100%;
+
+      .product-media__image {
+        height: 100%;
+      }
+    }
+
+    .product-media__drag-zoom-wrapper {
+      display: flex;
+      aspect-ratio: auto;
+      height: 100%;
+      width: 100%;
+      overflow: scroll;
+      scrollbar-width: none;
+      justify-content: center;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+
+    .product-media__drag-zoom-wrapper .product-media__image {
+      --product-media-fit: contain;
+      overflow: hidden;
+      transform: scale(var(--drag-zoom-scale))
+        translate(var(--drag-zoom-translate-x, 0), var(--drag-zoom-translate-y, 0));
+    }
+
+    .media-gallery--hint {
+      --slideshow-gap: var(--gap-2xs);
+
+      :not(.dialog-zoomed-gallery) > .product-media-container:not(:only-child) {
+        width: 90%;
+
+        .product-media img {
+          object-fit: cover;
+        }
+      }
+    }
+  }
+
+  .dialog-zoomed-gallery__close-button {
+    border-radius: 50%;
+    color: white;
+    mix-blend-mode: difference;
+    z-index: var(--layer-raised);
+  }
+
+  .media-gallery__mobile-controls {
+    grid-area: auto;
+  }
+
+  .dialog-zoomed-gallery .product-media-container--zoomable.product-media-container--image {
+    cursor: zoom-out;
+  }
+
+  .product-media-container--zoomable.product-media-container--image {
+    cursor: zoom-in;
+  }
+
+  .dialog-zoomed-gallery .product-media-container--video deferred-media,
+  .dialog-zoomed-gallery .product-media-container--external_video deferred-media {
+    height: auto;
+    aspect-ratio: var(--ratio);
+  }
+
+  .dialog-zoomed-gallery .product-media-container--model .product-media__image {
+    /* Make the height match the height of the model-viewer */
+    height: 100vh;
+  }
+{% endstylesheet %}
+
+{% schema %}
+{
+  "name": "t:names.product_media",
+  "tag": null,
+  "settings": [
+    {
+      "type": "product",
+      "id": "product",
+      "label": "t:settings.product"
+    },
+    {
+      "type": "select",
+      "id": "media_presentation",
+      "label": "t:settings.type",
+      "options": [
+        {
+          "value": "grid",
+          "label": "t:options.grid"
+        },
+        {
+          "value": "carousel",
+          "label": "t:options.carousel"
+        }
+      ],
+      "default": "grid",
+      "info": "t:info.carousel_layout_on_mobile"
+    },
+    {
+      "type": "header",
+      "content": "t:content.grid",
+      "visible_if": "{{ block.settings.media_presentation == 'grid' }}"
+    },
+    {
+      "type": "select",
+      "id": "media_columns",
+      "label": "t:settings.columns",
+      "options": [
+        {
+          "value": "one",
+          "label": "t:options.one_number"
+        },
+        {
+          "value": "two",
+          "label": "t:options.two_number"
+        }
+      ],
+      "default": "one",
+      "visible_if": "{{ block.settings.media_presentation == 'grid' }}"
+    },
+    {
+      "type": "range",
+      "id": "image_gap",
+      "label": "t:settings.gap",
+      "min": 0,
+      "max": 100,
+      "unit": "px",
+      "step": 1,
+      "default": 0,
+      "visible_if": "{{ block.settings.media_presentation == 'grid' }}"
+    },
+    {
+      "type": "checkbox",
+      "id": "large_first_image",
+      "label": "t:settings.full_width_first_image",
+      "default": false,
+      "visible_if": "{{ block.settings.media_presentation == 'grid' and block.settings.media_columns == 'two' }}"
+    },
+    {
+      "type": "header",
+      "content": "t:content.carousel"
+    },
+    {
+      "type": "select",
+      "id": "icons_style",
+      "label": "t:settings.icons",
+      "options": [
+        {
+          "value": "arrow",
+          "label": "t:options.arrows"
+        },
+        {
+          "value": "chevron",
+          "label": "t:options.chevrons"
+        },
+        {
+          "value": "arrows_large",
+          "label": "t:options.large_arrows"
+        },
+        {
+          "value": "chevron_large",
+          "label": "t:options.large_chevrons"
+        }
+      ],
+      "default": "arrow",
+      "visible_if": "{{ block.settings.media_presentation == 'carousel' }}"
+    },
+    {
+      "type": "select",
+      "id": "slideshow_controls_style",
+      "label": "t:settings.pagination",
+      "options": [
+        {
+          "value": "dots",
+          "label": "t:options.dots"
+        },
+        {
+          "value": "counter",
+          "label": "t:options.counter"
+        },
+        {
+          "value": "thumbnails",
+          "label": "t:options.thumbnails"
+        }
+      ],
+      "visible_if": "{{ block.settings.media_presentation == 'carousel' }}"
+    },
+    {
+      "type": "select",
+      "id": "slideshow_mobile_controls_style",
+      "label": "t:settings.mobile_pagination",
+      "options": [
+        {
+          "value": "dots",
+          "label": "t:options.dots"
+        },
+        {
+          "value": "counter",
+          "label": "t:options.counter"
+        },
+        {
+          "value": "hint",
+          "label": "t:options.hint"
+        }
+      ]
+    },
+    {
+      "type": "header",
+      "content": "t:content.thumbnails",
+      "visible_if": "{{ block.settings.media_presentation == 'carousel' and block.settings.slideshow_controls_style == 'thumbnails' }}"
+    },
+    {
+      "type": "select",
+      "id": "thumbnail_position",
+      "label": "t:settings.position",
+      "options": [
+        {
+          "value": "left",
+          "label": "t:options.left"
+        },
+        {
+          "value": "bottom",
+          "label": "t:options.bottom"
+        },
+        {
+          "value": "right",
+          "label": "t:options.right"
+        }
+      ],
+      "default": "bottom",
+      "visible_if": "{{ block.settings.media_presentation == 'carousel' and block.settings.slideshow_controls_style == 'thumbnails' }}"
+    },
+    {
+      "type": "range",
+      "id": "thumbnail_width",
+      "label": "t:settings.width",
+      "min": 44,
+      "max": 72,
+      "step": 1,
+      "unit": "px",
+      "default": 64,
+      "visible_if": "{{ block.settings.media_presentation == 'carousel' and block.settings.slideshow_controls_style == 'thumbnails' }}"
+    },
+    {
+      "type": "header",
+      "content": "t:content.media"
+    },
+    {
+      "type": "select",
+      "id": "aspect_ratio",
+      "label": "t:settings.aspect_ratio",
+      "options": [
+        {
+          "value": "adapt",
+          "label": "t:options.auto"
+        },
+        {
+          "value": "1/1.25",
+          "label": "t:options.portrait"
+        },
+        {
+          "value": "1",
+          "label": "t:options.square"
+        },
+        {
+          "value": "2/1",
+          "label": "t:options.landscape"
+        }
+      ],
+      "default": "adapt"
+    },
+    {
+      "type": "range",
+      "id": "media_radius",
+      "label": "t:settings.border_radius",
+      "min": 0,
+      "max": 32,
+      "step": 1,
+      "unit": "px",
+      "default": 4
+    },
+    {
+      "type": "checkbox",
+      "id": "extend_media",
+      "label": "t:settings.extend_media_to_screen_edge",
+      "default": true,
+      "visible_if": "{{ section.settings.content_width == 'content-center-aligned' }}"
+    },
+    {
+      "type": "checkbox",
+      "id": "constrain_to_viewport",
+      "label": "t:settings.limit_media_to_screen_height",
+      "default": false
+    },
+    {
+      "type": "checkbox",
+      "id": "zoom",
+      "label": "t:settings.enable_zoom",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "video_loop",
+      "label": "t:settings.enable_video_looping",
+      "default": false
+    },
+    {
+      "type": "checkbox",
+      "id": "hide_variants",
+      "default": false,
+      "label": "t:settings.hide_unselected_variant_media"
+    },
+    {
+      "type": "header",
+      "content": "t:content.padding"
+    },
+    {
+      "type": "range",
+      "id": "padding-block-start",
+      "label": "t:settings.top",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "padding-block-end",
+      "label": "t:settings.bottom",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "padding-inline-start",
+      "label": "t:settings.left",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "padding-inline-end",
+      "label": "t:settings.right",
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px",
+      "default": 0
+    }
+  ],
+  "presets": [
+    {
+      "name": "t:names.product_media",
+      "settings": {
+        "product": "{{ closest.product }}"
+      }
+    }
+  ]
+}
+{% endschema %}

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -3,7 +3,7 @@
 client_id = "1e12e608ca0a9afcd087a76c1152fa47"
 name = "designer"
 handle = "designer-17"
-application_url = "https://tales-bedding-qualification-effective.trycloudflare.com"
+application_url = "https://closest-tag-suit-tops.trycloudflare.com"
 embedded = true
 
 [build]
@@ -27,13 +27,13 @@ scopes = "write_products"
 
 [auth]
 redirect_urls = [
-  "https://tales-bedding-qualification-effective.trycloudflare.com/auth/callback",
-  "https://tales-bedding-qualification-effective.trycloudflare.com/auth/shopify/callback",
-  "https://tales-bedding-qualification-effective.trycloudflare.com/api/auth/callback"
+  "https://closest-tag-suit-tops.trycloudflare.com/auth/callback",
+  "https://closest-tag-suit-tops.trycloudflare.com/auth/shopify/callback",
+  "https://closest-tag-suit-tops.trycloudflare.com/api/auth/callback"
 ]
 
 [app_proxy]
-url = "https://tales-bedding-qualification-effective.trycloudflare.com"
+url = "https://closest-tag-suit-tops.trycloudflare.com"
 subpath = "designer"
 prefix = "apps"
 


### PR DESCRIPTION
## Summary
- Added comprehensive plan for implementing blur/fade transitions when switching variants
- Addresses the ~1 second delay where users see non-customized images during Konva generation

## Plan Details
The plan outlines:
- CSS blur transition implementation
- Smooth image loading with preload
- Integration with existing cache system
- Timeline improvements from 1s jarring switch to ~300ms smooth transition

See PLAN_BLUR_PRODUCT_IMAGE_DURING_GENERATION.md for full implementation details.

🤖 Generated with [Claude Code](https://claude.ai/code)