### PR TITLE
fix: Update slideshow thumbnails when switching variants

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -3,7 +3,7 @@
 client_id = "1e12e608ca0a9afcd087a76c1152fa47"
 name = "designer"
 handle = "designer-17"
-application_url = "https://closest-tag-suit-tops.trycloudflare.com"
+application_url = "https://directories-suggesting-juice-rapid.trycloudflare.com"
 embedded = true
 
 [build]
@@ -27,13 +27,13 @@ scopes = "write_products"
 
 [auth]
 redirect_urls = [
-  "https://closest-tag-suit-tops.trycloudflare.com/auth/callback",
-  "https://closest-tag-suit-tops.trycloudflare.com/auth/shopify/callback",
-  "https://closest-tag-suit-tops.trycloudflare.com/api/auth/callback"
+  "https://directories-suggesting-juice-rapid.trycloudflare.com/auth/callback",
+  "https://directories-suggesting-juice-rapid.trycloudflare.com/auth/shopify/callback",
+  "https://directories-suggesting-juice-rapid.trycloudflare.com/api/auth/callback"
 ]
 
 [app_proxy]
-url = "https://closest-tag-suit-tops.trycloudflare.com"
+url = "https://directories-suggesting-juice-rapid.trycloudflare.com"
 subpath = "designer"
 prefix = "apps"
 


### PR DESCRIPTION
## Summary
  This PR fixes an issue where slideshow/carousel thumbnails were not updating when users switched variants after customizing text.

  ## Problem
  When users:
  1. Customize front and back text (e.g., 'CAT' and 'DOG')
  2. Switch to a different variant
  3. The main product image updates correctly, but thumbnails show default template text

  ## Solution
  - Modified `updateProductImageForVariant()` to also update slideshow thumbnails
  - For dual-sided templates, generates both front and back previews
  - Calls existing `updateSlideshowThumbnails()` method to update carousel

  ## Test Plan
  1. Click 'Customize this Product' on a dual-sided variant
  2. Change front text to 'CAT'
  3. Change back text to 'DOG'
  4. Click Done
  5. Switch to a different color variant
  6. Verify:
     - Main product image shows 'CAT'
     - Front thumbnail shows 'CAT'
     - Back thumbnail shows 'DOG'
     - Switching between front/back views works correctly