### PR TITLE
Fix variant swatch updates when switching edge patterns with customizations

### DIFF
--- a/app/services/variant-swatch-generator.server.ts
+++ b/app/services/variant-swatch-generator.server.ts
@@ -124,13 +124,36 @@ export async function generateVariantSwatch({
 function applyTextCustomizations(state: any, textUpdates: Record<string, string>): any {
   const newState = JSON.parse(JSON.stringify(state));
   
+  console.log('[Swatch Generator] Applying text customizations. Available updates:', Object.keys(textUpdates));
+  
   // Update text elements
   if (newState.elements) {
     ['textElements', 'curvedTextElements', 'gradientTextElements'].forEach(elementType => {
       if (newState.elements[elementType]) {
         newState.elements[elementType].forEach((element: any) => {
+          let textApplied = false;
+          
+          // Try direct match first
           if (textUpdates[element.id]) {
+            console.log(`[Swatch Generator] Direct match found for ${element.id}, updating text to: "${textUpdates[element.id]}"`);
             element.text = textUpdates[element.id];
+            textApplied = true;
+          } 
+          // Try with front_ prefix
+          else if (textUpdates[`front_${element.id}`]) {
+            console.log(`[Swatch Generator] Front prefix match found for ${element.id}, updating text to: "${textUpdates[`front_${element.id}`]}"`);
+            element.text = textUpdates[`front_${element.id}`];
+            textApplied = true;
+          }
+          // Try with back_ prefix
+          else if (textUpdates[`back_${element.id}`]) {
+            console.log(`[Swatch Generator] Back prefix match found for ${element.id}, updating text to: "${textUpdates[`back_${element.id}`]}"`);
+            element.text = textUpdates[`back_${element.id}`];
+            textApplied = true;
+          }
+          
+          if (!textApplied) {
+            console.log(`[Swatch Generator] No match found for element ${element.id} in ${elementType}. Current text: "${element.text}"`);
           }
         });
       }


### PR DESCRIPTION
## Summary
- Fixed variant swatches not updating when users switch edge patterns (e.g., from "8 Spot" to "Double Stripe") while having text customizations
- Swatches now correctly display customized text on all color variants when pattern changes

## Problem
When users:
1. Customize text (e.g., "CAT" on front, "DOG" on back)
2. Switch from one edge pattern to another (e.g., "8 Spot" → "Double Stripe")

The color variant swatches would incorrectly show the default template text instead of the customized text.

## Solution

### Client-Side Changes (`product-customizer-modal.js`)
- Added pattern change detection in `updateProductImageIfCustomized`
- Created `updateVariantSwatchesForPatternChange` function to regenerate swatches when pattern changes
- Detects pattern changes by parsing variant titles and comparing patterns
- Calls server API with current text customizations to generate updated swatches

### Server-Side Changes (`variant-swatch-generator.server.ts`)
- Fixed `applyTextCustomizations` to handle prefixed text IDs from dual-sided templates
- Now matches both direct IDs (`text-123`) and prefixed IDs (`front_text-123`, `back_text-123`)
- Added detailed logging for debugging text update matching

## Test Plan
1. Open a product with dual-sided template (e.g., poker chips)
2. Click "Customize this Product"
3. Change front text to "CAT" and back text to "DOG"
4. Click "Done" to save customizations
5. Change edge pattern (e.g., from "8 Spot" to "Double Stripe")
6. Verify all color swatches update to show "CAT" text (not default "FRONT")
7. Check browser console for pattern change detection logs

🤖 Generated with [Claude Code](https://claude.ai/code)