### PR TITLE
Fix curved text cutoff and shape rendering in thumbnails

### DIFF
--- a/app/routes/api.test-template-render.tsx
+++ b/app/routes/api.test-template-render.tsx
@@ -304,7 +304,19 @@ export async function action({ request }: ActionFunctionArgs) {
         
         // Calculate text length and angle span
         const fontSize = element.fontSize || 20;
-        const textLength = element.text.length * fontSize * 0.6;
+        
+        // Measure actual text width using a temporary Konva Text node
+        const tempText = new Konva.Text({
+          text: element.text,
+          fontSize: fontSize,
+          fontFamily: element.fontFamily || 'Arial',
+          fontStyle: element.fontWeight === 'bold' ? 'bold' : 'normal'
+        });
+        const measuredWidth = tempText.width();
+        tempText.destroy(); // Clean up temporary node
+        
+        // Use measured width with padding for better spacing
+        const textLength = measuredWidth * 1.1; // Add 10% padding
         const circumference = 2 * Math.PI * element.radius;
         const angleSpan = Math.min((textLength / circumference) * 2 * Math.PI, 1.5 * Math.PI);
         

--- a/app/services/template-thumbnail-generator.server.ts
+++ b/app/services/template-thumbnail-generator.server.ts
@@ -323,7 +323,19 @@ export async function generateTemplateThumbnail(
         
         // Calculate text length and angle span
         const fontSize = element.fontSize || 20;
-        const textLength = element.text.length * fontSize * 0.6;
+        
+        // Measure actual text width using a temporary Konva Text node
+        const tempText = new Konva.Text({
+          text: element.text,
+          fontSize: fontSize,
+          fontFamily: element.fontFamily || 'Arial',
+          fontStyle: element.fontWeight === 'bold' ? 'bold' : 'normal'
+        });
+        const measuredWidth = tempText.width();
+        tempText.destroy(); // Clean up temporary node
+        
+        // Use measured width with padding for better spacing
+        const textLength = measuredWidth * 1.1; // Add 10% padding
         const circumference = 2 * Math.PI * element.radius;
         const angleSpan = Math.min((textLength / circumference) * 2 * Math.PI, 1.5 * Math.PI);
         

--- a/app/services/template-thumbnail-generator.server.ts
+++ b/app/services/template-thumbnail-generator.server.ts
@@ -268,7 +268,7 @@ export async function generateTemplateThumbnail(
     state.elements.shapeElements?.forEach((element: any) => {
       allElements.push({ 
         ...element, 
-        type: 'shape',
+        elementType: 'shape', // Use elementType to preserve original type
         zIndex: element.zIndex !== undefined ? element.zIndex : defaultZIndex++
       });
     });
@@ -421,7 +421,7 @@ export async function generateTemplateThumbnail(
             console.error('Failed to create Konva.Image for user image:', error);
           }
         }
-      } else if (element.type === 'shape') {
+      } else if (element.elementType === 'shape') {
         console.log('Rendering shape element:', element.type, 'zIndex:', element.zIndex || 0);
         
         const commonProps = {

--- a/app/services/variant-swatch-generator.server.ts
+++ b/app/services/variant-swatch-generator.server.ts
@@ -396,7 +396,19 @@ async function renderSwatch(state: any, size: number, quality: number): Promise<
         
         // Calculate text length and angle span
         const fontSize = element.fontSize || 20;
-        const textLength = element.text.length * fontSize * 0.6;
+        
+        // Measure actual text width using a temporary Konva Text node
+        const tempText = new Konva.Text({
+          text: element.text,
+          fontSize: fontSize,
+          fontFamily: element.fontFamily || 'Arial',
+          fontStyle: element.fontWeight === 'bold' ? 'bold' : 'normal'
+        });
+        const measuredWidth = tempText.width();
+        tempText.destroy(); // Clean up temporary node
+        
+        // Use measured width with padding for better spacing
+        const textLength = measuredWidth * 1.1; // Add 10% padding
         const circumference = 2 * Math.PI * element.radius;
         const angleSpan = Math.min((textLength / circumference) * 2 * Math.PI, 1.5 * Math.PI);
         

--- a/extensions/canvas-api-pdp/assets/canvas-text-renderer.js
+++ b/extensions/canvas-api-pdp/assets/canvas-text-renderer.js
@@ -520,7 +520,19 @@ if (typeof CanvasTextRenderer === 'undefined') {
 
         // Calculate text path
         const fontSize = el.fontSize || 20;
-        const textLength = text.length * fontSize * 0.6;
+        
+        // Measure actual text width using a temporary Konva Text node
+        const tempText = new Konva.Text({
+          text: text,
+          fontSize: fontSize,
+          fontFamily: el.fontFamily || 'Arial',
+          fontStyle: el.fontWeight === 'bold' ? 'bold' : 'normal'
+        });
+        const measuredWidth = tempText.width();
+        tempText.destroy(); // Clean up temporary node
+        
+        // Use measured width with padding for better spacing
+        const textLength = measuredWidth * 1.1; // Add 10% padding
         const angleSpan = Math.min(textLength / el.radius, Math.PI * 1.5);
         
         let startAngle, endAngle, sweepFlag;

--- a/extensions/canvas-api-pdp/assets/product-customizer-modal.js
+++ b/extensions/canvas-api-pdp/assets/product-customizer-modal.js
@@ -3673,7 +3673,19 @@ if (typeof ProductCustomizerModal === 'undefined') {
             // Calculate text path
             const fontSize = el.fontSize || 20;
             const textContent = el.text;
-            const textLength = textContent.length * fontSize * 0.6;
+            
+            // Measure actual text width using a temporary Konva Text node
+            const tempText = new Konva.Text({
+              text: textContent,
+              fontSize: fontSize,
+              fontFamily: el.fontFamily || 'Arial',
+              fontStyle: el.fontWeight === 'bold' ? 'bold' : 'normal'
+            });
+            const measuredWidth = tempText.width();
+            tempText.destroy(); // Clean up temporary node
+            
+            // Use measured width with padding for better spacing
+            const textLength = measuredWidth * 1.1; // Add 10% padding
             const angleSpan = Math.min(textLength / el.radius, Math.PI * 1.5);
             
             let startAngle, endAngle, sweepFlag;


### PR DESCRIPTION
## Summary
- Fixed curved text being cut off (e.g., "YOUR COMPANY INFORMATION" displaying as "YOUR COMPANY INFORMATI")
- Fixed shape elements (rect, ellipse, ring) not rendering in template thumbnails

## Problems Fixed

### 1. Curved Text Cutoff
The text width calculation used a simplistic formula `text.length * fontSize * 0.6` which didn't account for actual font metrics, kerning, or variable character widths. This caused curved text to be truncated.

### 2. Shape Rendering
Shape elements weren't rendering in thumbnails because the code was overwriting their `type` property with 'shape', breaking the shape-specific rendering logic that checks for 'rect', 'ellipse', or 'ring'.

## Solution

### Curved Text Fix
Replaced the approximation with proper text measurement using Konva's Text node to get the actual rendered width:
```javascript
const tempText = new Konva.Text({
  text: text,
  fontSize: fontSize,
  fontFamily: el.fontFamily || 'Arial',
  fontStyle: el.fontWeight === 'bold' ? 'bold' : 'normal'
});
const measuredWidth = tempText.width();
const textLength = measuredWidth * 1.1; // Add 10% padding
```

### Shape Rendering Fix
Changed to use `elementType: 'shape'` to identify shape elements while preserving the original `type` property needed for rendering:
```javascript
// Before: type: 'shape' (overwrites original)
// After: elementType: 'shape' (preserves original type)
```

## Files Changed
- `canvas-text-renderer.js` - Fixed curved text in product customizer
- `product-customizer-modal.js` - Fixed curved text in modal preview
- `api.test-template-render.tsx` - Fixed curved text in server rendering
- `template-thumbnail-generator.server.ts` - Fixed both curved text and shape rendering
- `variant-swatch-generator.server.ts` - Fixed curved text in swatch generation

## Test Plan
- [x] Create a template with curved text containing "YOUR COMPANY INFORMATION"
- [x] Add shape elements (rectangles, ellipses, rings) to the template
- [x] Save the template and generate color variants
- [x] Process pending thumbnails
- [x] Verify curved text renders completely without cutoff
- [x] Verify all shape elements render correctly in thumbnails
- [x] Test in product customizer modal to ensure text renders correctly there too

🤖 Generated with Claude Code