### PR TITLE
fix: Generate unique IDs when copying elements for 'Same artwork on both sides'

### DIFF
--- a/app/components/DesignerCanvas.tsx
+++ b/app/components/DesignerCanvas.tsx
@@ -162,6 +162,47 @@ interface DesignerCanvasProps {
 }
 
 const DesignerCanvas: React.FC<DesignerCanvasProps> = ({ initialTemplate, productLayout, shopifyProduct, shopifyVariant, layoutVariant, initialState, onSave, isAdminView = true, templateColors = [], initialColorVariant }) => {
+  // Helper function to generate unique IDs
+  const generateUniqueId = (type: string) => {
+    return `${type}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  };
+
+  // Deep copy functions for each element type
+  const deepCopyTextElements = (elements: Array<{id: string, text: string, x: number, y: number, fontFamily: string, fontSize?: number, fontWeight?: string, fill?: string, stroke?: string, strokeWidth?: number, rotation?: number, scaleX?: number, scaleY?: number, zIndex?: number}>) => {
+    return elements.map(el => ({
+      ...el,
+      id: generateUniqueId('text')
+    }));
+  };
+
+  const deepCopyCurvedTextElements = (elements: Array<{id: string, text: string, x: number, topY: number, radius: number, flipped: boolean, fontFamily: string, fontSize?: number, fontWeight?: string, fill?: string, stroke?: string, strokeWidth?: number, rotation?: number, scaleX?: number, scaleY?: number, zIndex?: number}>) => {
+    return elements.map(el => ({
+      ...el,
+      id: generateUniqueId('curved-text')
+    }));
+  };
+
+  const deepCopyGradientTextElements = (elements: Array<{id: string, text: string, x: number, y: number, fontFamily: string, fontSize?: number, rotation?: number, scaleX?: number, scaleY?: number, zIndex?: number}>) => {
+    return elements.map(el => ({
+      ...el,
+      id: generateUniqueId('gradient-text')
+    }));
+  };
+
+  const deepCopyImageElements = (elements: Array<{id: string, url: string, x: number, y: number, width: number, height: number, rotation?: number, zIndex?: number}>) => {
+    return elements.map(el => ({
+      ...el,
+      id: generateUniqueId('image')
+    }));
+  };
+
+  const deepCopyShapeElements = (elements: Array<ShapeElement>) => {
+    return elements.map(el => ({
+      ...el,
+      id: generateUniqueId('shape')
+    }));
+  };
+
   const shapeRef = React.useRef(null);
   const stageRef = React.useRef<any>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -512,12 +553,12 @@ const DesignerCanvas: React.FC<DesignerCanvasProps> = ({ initialTemplate, produc
   // Sync front to back when enabling same design mode
   React.useEffect(() => {
     if (sameDesignBothSides) {
-      // Copy all front elements to back
-      setBackTextElements([...frontTextElements]);
-      setBackGradientTextElements([...frontGradientTextElements]);
-      setBackCurvedTextElements([...frontCurvedTextElements]);
-      setBackImageElements([...frontImageElements]);
-      setBackShapeElements([...frontShapeElements]);
+      // Copy all front elements to back with new unique IDs
+      setBackTextElements(deepCopyTextElements(frontTextElements));
+      setBackGradientTextElements(deepCopyGradientTextElements(frontGradientTextElements));
+      setBackCurvedTextElements(deepCopyCurvedTextElements(frontCurvedTextElements));
+      setBackImageElements(deepCopyImageElements(frontImageElements));
+      setBackShapeElements(deepCopyShapeElements(frontShapeElements));
       setBackBackgroundColor(frontBackgroundColor);
       
       // Force current side to front
@@ -535,11 +576,11 @@ const DesignerCanvas: React.FC<DesignerCanvasProps> = ({ initialTemplate, produc
   // Auto-sync front to back when same design mode is on
   React.useEffect(() => {
     if (sameDesignBothSides && currentSide === 'front') {
-      setBackTextElements([...frontTextElements]);
-      setBackGradientTextElements([...frontGradientTextElements]);
-      setBackCurvedTextElements([...frontCurvedTextElements]);
-      setBackImageElements([...frontImageElements]);
-      setBackShapeElements([...frontShapeElements]);
+      setBackTextElements(deepCopyTextElements(frontTextElements));
+      setBackGradientTextElements(deepCopyGradientTextElements(frontGradientTextElements));
+      setBackCurvedTextElements(deepCopyCurvedTextElements(frontCurvedTextElements));
+      setBackImageElements(deepCopyImageElements(frontImageElements));
+      setBackShapeElements(deepCopyShapeElements(frontShapeElements));
       setBackBackgroundColor(frontBackgroundColor);
     }
   }, [
@@ -1389,11 +1430,20 @@ const DesignerCanvas: React.FC<DesignerCanvasProps> = ({ initialTemplate, produc
           (window as any).__tempBackgroundGradient = sideState.backgroundGradient;
         }
         if (sideState.elements) {
-          if (sideState.elements.textElements) setBackTextElements(sideState.elements.textElements);
-          if (sideState.elements.curvedTextElements) setBackCurvedTextElements(sideState.elements.curvedTextElements);
-          if (sideState.elements.gradientTextElements) setBackGradientTextElements(sideState.elements.gradientTextElements);
-          if (sideState.elements.imageElements) setBackImageElements(sideState.elements.imageElements);
-          if (sideState.elements.shapeElements) setBackShapeElements(sideState.elements.shapeElements);
+          // If sameDesignBothSides is true, create unique IDs for back elements
+          if (state.sameDesignBothSides) {
+            if (sideState.elements.textElements) setBackTextElements(deepCopyTextElements(sideState.elements.textElements));
+            if (sideState.elements.curvedTextElements) setBackCurvedTextElements(deepCopyCurvedTextElements(sideState.elements.curvedTextElements));
+            if (sideState.elements.gradientTextElements) setBackGradientTextElements(deepCopyGradientTextElements(sideState.elements.gradientTextElements));
+            if (sideState.elements.imageElements) setBackImageElements(deepCopyImageElements(sideState.elements.imageElements));
+            if (sideState.elements.shapeElements) setBackShapeElements(deepCopyShapeElements(sideState.elements.shapeElements));
+          } else {
+            if (sideState.elements.textElements) setBackTextElements(sideState.elements.textElements);
+            if (sideState.elements.curvedTextElements) setBackCurvedTextElements(sideState.elements.curvedTextElements);
+            if (sideState.elements.gradientTextElements) setBackGradientTextElements(sideState.elements.gradientTextElements);
+            if (sideState.elements.imageElements) setBackImageElements(sideState.elements.imageElements);
+            if (sideState.elements.shapeElements) setBackShapeElements(sideState.elements.shapeElements);
+          }
         }
         if (sideState.assets?.baseImage) setBackBaseImageUrl(sideState.assets.baseImage);
       }

--- a/scripts/check-template-dates.js
+++ b/scripts/check-template-dates.js
@@ -1,0 +1,81 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function checkTemplateDates(templateId) {
+  try {
+    const template = await prisma.template.findUnique({
+      where: { id: templateId },
+      select: {
+        id: true,
+        name: true,
+        createdAt: true,
+        updatedAt: true,
+        frontCanvasData: true,
+        backCanvasData: true
+      }
+    });
+
+    if (!template) {
+      console.log('Template not found');
+      return;
+    }
+
+    console.log(`\nTemplate: ${template.name} (${template.id})`);
+    console.log(`Created: ${template.createdAt}`);
+    console.log(`Updated: ${template.updatedAt}`);
+    
+    // Check if sameDesignBothSides flag is present
+    let hasSameDesignFlag = false;
+    if (template.frontCanvasData) {
+      const frontData = JSON.parse(template.frontCanvasData);
+      if (frontData.sameDesignBothSides !== undefined) {
+        hasSameDesignFlag = true;
+        console.log(`\n"Same artwork on both sides" flag: ${frontData.sameDesignBothSides}`);
+      }
+    }
+    
+    if (!hasSameDesignFlag) {
+      console.log('\n⚠️  This template does not have the "sameDesignBothSides" flag.');
+      console.log('It was likely created before the feature was added.');
+    }
+    
+    // Check if front and back are identical (might indicate it was created with the toggle)
+    if (template.frontCanvasData && template.backCanvasData) {
+      const frontData = JSON.parse(template.frontCanvasData);
+      const backData = JSON.parse(template.backCanvasData);
+      
+      // Compare element counts
+      const frontElementCount = (frontData.elements?.textElements?.length || 0) +
+                               (frontData.elements?.curvedTextElements?.length || 0) +
+                               (frontData.elements?.imageElements?.length || 0) +
+                               (frontData.elements?.shapeElements?.length || 0);
+                               
+      const backElementCount = (backData.elements?.textElements?.length || 0) +
+                              (backData.elements?.curvedTextElements?.length || 0) +
+                              (backData.elements?.imageElements?.length || 0) +
+                              (backData.elements?.shapeElements?.length || 0);
+      
+      console.log(`\nFront elements: ${frontElementCount}`);
+      console.log(`Back elements: ${backElementCount}`);
+      
+      if (frontElementCount === backElementCount && frontElementCount > 0) {
+        console.log('\n📋 Front and back have the same number of elements.');
+      }
+    }
+
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Get template ID from command line argument
+const templateId = process.argv[2];
+
+if (!templateId) {
+  console.log('Usage: node check-template-dates.js <template-id>');
+  process.exit(1);
+}
+
+checkTemplateDates(templateId);

--- a/scripts/check-template-ids.js
+++ b/scripts/check-template-ids.js
@@ -1,0 +1,71 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function queryTemplate() {
+  try {
+    const template = await prisma.template.findUnique({
+      where: { id: 'cmcme9ggp000177sieni0oejl' },
+      select: {
+        id: true,
+        name: true,
+        frontCanvasData: true,
+        backCanvasData: true
+      }
+    });
+
+    if (!template) {
+      console.log('Template not found');
+      return;
+    }
+
+    console.log('Template found:', template.name);
+    console.log('\n=== FRONT CANVAS DATA ===');
+    
+    if (template.frontCanvasData) {
+      const frontData = JSON.parse(template.frontCanvasData);
+      console.log('Front Curved Text Elements:');
+      if (frontData.elements && frontData.elements.curvedTextElements) {
+        frontData.elements.curvedTextElements.forEach(element => {
+          console.log(`- ID: ${element.id}, Text: "${element.text}"`);
+        });
+      }
+    }
+
+    console.log('\n=== BACK CANVAS DATA ===');
+    
+    if (template.backCanvasData) {
+      const backData = JSON.parse(template.backCanvasData);
+      console.log('Back Curved Text Elements:');
+      if (backData.elements && backData.elements.curvedTextElements) {
+        backData.elements.curvedTextElements.forEach(element => {
+          console.log(`- ID: ${element.id}, Text: "${element.text}"`);
+        });
+      }
+    }
+
+    // Compare IDs
+    if (template.frontCanvasData && template.backCanvasData) {
+      const frontData = JSON.parse(template.frontCanvasData);
+      const backData = JSON.parse(template.backCanvasData);
+      
+      const frontCurvedIds = frontData.elements?.curvedTextElements?.map(e => e.id) || [];
+      const backCurvedIds = backData.elements?.curvedTextElements?.map(e => e.id) || [];
+      
+      console.log('\n=== ID COMPARISON ===');
+      console.log('Front Curved Text IDs:', frontCurvedIds);
+      console.log('Back Curved Text IDs:', backCurvedIds);
+      
+      const duplicateIds = frontCurvedIds.filter(id => backCurvedIds.includes(id));
+      if (duplicateIds.length > 0) {
+        console.log('\n⚠️  DUPLICATE IDs FOUND:', duplicateIds);
+      }
+    }
+
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+queryTemplate();

--- a/scripts/test-unique-ids.js
+++ b/scripts/test-unique-ids.js
@@ -1,0 +1,95 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function testUniqueIds(templateId) {
+  try {
+    const template = await prisma.template.findUnique({
+      where: { id: templateId },
+      select: {
+        id: true,
+        name: true,
+        frontCanvasData: true,
+        backCanvasData: true
+      }
+    });
+
+    if (!template) {
+      console.log('Template not found');
+      return;
+    }
+
+    console.log(`\nTemplate: ${template.name} (${template.id})`);
+    console.log('=' .repeat(60));
+    
+    // Extract all IDs from front and back
+    const frontIds = new Set();
+    const backIds = new Set();
+    
+    if (template.frontCanvasData) {
+      const frontData = JSON.parse(template.frontCanvasData);
+      
+      // Extract IDs from all element types
+      ['textElements', 'curvedTextElements', 'gradientTextElements', 'imageElements', 'shapeElements'].forEach(elementType => {
+        if (frontData.elements && frontData.elements[elementType]) {
+          frontData.elements[elementType].forEach(el => {
+            frontIds.add(el.id);
+          });
+        }
+      });
+    }
+    
+    if (template.backCanvasData) {
+      const backData = JSON.parse(template.backCanvasData);
+      
+      // Extract IDs from all element types
+      ['textElements', 'curvedTextElements', 'gradientTextElements', 'imageElements', 'shapeElements'].forEach(elementType => {
+        if (backData.elements && backData.elements[elementType]) {
+          backData.elements[elementType].forEach(el => {
+            backIds.add(el.id);
+          });
+        }
+      });
+    }
+    
+    // Check for duplicate IDs
+    const duplicateIds = [...frontIds].filter(id => backIds.has(id));
+    
+    console.log(`\nFront Canvas Element IDs (${frontIds.size} total):`);
+    [...frontIds].sort().forEach(id => console.log(`  - ${id}`));
+    
+    console.log(`\nBack Canvas Element IDs (${backIds.size} total):`);
+    [...backIds].sort().forEach(id => console.log(`  - ${id}`));
+    
+    console.log('\n' + '=' .repeat(60));
+    if (duplicateIds.length > 0) {
+      console.log('❌ DUPLICATE IDs FOUND:');
+      duplicateIds.forEach(id => console.log(`  - ${id}`));
+    } else {
+      console.log('✅ No duplicate IDs found - All element IDs are unique!');
+    }
+    
+    // Check if "sameDesignBothSides" flag is set
+    if (template.frontCanvasData) {
+      const frontData = JSON.parse(template.frontCanvasData);
+      if (frontData.sameDesignBothSides !== undefined) {
+        console.log(`\n"Same artwork on both sides" toggle: ${frontData.sameDesignBothSides ? 'ENABLED' : 'DISABLED'}`);
+      }
+    }
+
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Get template ID from command line argument
+const templateId = process.argv[2];
+
+if (!templateId) {
+  console.log('Usage: node test-unique-ids.js <template-id>');
+  console.log('Example: node test-unique-ids.js cmcme9ggp000177sieni0oejl');
+  process.exit(1);
+}
+
+testUniqueIds(templateId);


### PR DESCRIPTION
## Summary
- Fixed duplicate element IDs when using "Same artwork on both sides" toggle
- Elements copied from front to back now receive unique IDs
- Prevents canvas rendering conflicts and database integrity issues

## Problem
When the "Same artwork on both sides" feature was enabled, elements were shallow-copied from front to back, resulting in duplicate IDs. This caused:
- Canvas rendering issues when switching between sides
- Database records with conflicting element IDs
- Potential selection and manipulation problems

## Solution
1. Created `generateUniqueId()` helper function that generates IDs with timestamp and random suffix
2. Implemented deep copy functions for all element types:
   - `deepCopyTextElements`
   - `deepCopyCurvedTextElements`
   - `deepCopyGradientTextElements`
   - `deepCopyImageElements`
   - `deepCopyShapeElements`
3. Updated both sync mechanisms to use deep copy:
   - Initial sync when toggle is enabled
   - Auto-sync during edits
4. Fixed `loadCanvasState` to generate unique IDs when loading templates with `sameDesignBothSides` enabled

## Testing
Added utility scripts for verifying the fix:
- `scripts/test-unique-ids.js` - Check any template for duplicate IDs
- `scripts/check-template-dates.js` - Verify template metadata
- `scripts/check-template-ids.js` - Original Prisma query script

Tested with template `cmcme9ggp000177sieni0oejl` and confirmed unique IDs are generated.

🤖 Generated with [Claude Code](https://claude.ai/code)